### PR TITLE
Major update to spec; rewrite in bikeshed.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,0 +1,1016 @@
+<pre class="metadata">
+Title: Feature Policy
+Shortname: feature-policy
+Level: 1
+Status: CG-DRAFT
+Group: WICG
+URL: https://wicg.github.io/feature-policy/
+Editor: Ilya Grigorik, Google, igrigorik@google.com
+Editor: Mike West, Google, mkwst@google.com
+Abstract: This specification defines a mechanism that allows developers to selectively enable and disable use of various browser features and APIs.
+Repository: https://github.com/wicg/feature-policy/
+Markup Shorthands: css no, markdown yes
+</pre>
+<pre class="link-defaults">
+spec:html; type:interface; for:/; text:Document
+spec:url; type:dfn; text:origin
+spec:fetch; type:dfn; for:Response; text:response
+spec:html; type:dfn; for:/; text:browsing context
+spec:html; type:element; text:script
+spec:html; type:element; text:link
+spec:html; type:dfn; for:/; text:global object
+spec:html; type:dfn; for:/; text:header list
+spec:fetch; type:dfn; text:name
+spec:fetch; type:dfn; text:value
+</pre>
+<section>
+  <h2 id="introduction">Introduction</h2>
+  <p>The web-platform provides an ever-expanding set of features and APIs,
+  offering richer functionality, better developer ergonomics, and improved
+  performance. However, a missing piece is the ability for the developer to
+  selectively enable, disable, or modify the behavior of some of these browser
+  features and APIs within their application:</p>
+  <ol>
+    <li>The developer may want to selectively *disable* access to certain
+    browser features and APIs to "lock down" their application, as a security
+    or performance precaution, to prevent own and third-party content executing
+    within their application from introducing unwanted or unexpected behaviors
+    within their application.</li>
+    <li>The developer may want to selectively *enable* access to certain
+    browser features and APIs which may be disabled by default - e.g. some
+    features may be disabled by default in embedded context unless explicitly
+    enabled; some features may be subject to other policy requirements.</li>
+    <li>The developer may want to use the policy to assert a promise to a
+    client or an embedder about the use—or lack of thereof—of certain features
+    and APIs. For example, to enable certain types of "fast path" optimizations
+    in the browser, or to assert a promise about conformance with some
+    requirements set by other embedders - e.g. various social networks, search
+    engines, and so on.</li>
+  </ol>
+  <p>This specification defines a feature policy mechanism that addresses the
+  above use cases.</p>
+</section>
+<section>
+  <h2 id="examples">Examples</h2>
+  <div class="example">
+    <p>SecureCorp Inc. wants to disable use of Vibration and Geolocation APIs
+    within their application. It can do so by delivering the following HTTP
+    response header to define a feature policy:</p>
+    <pre>
+      <a href="#feature-policy-header">Feature-Policy</a>: {"<a>vibrate</a>": [], "<a>geolocation</a>": []}</pre>
+    <p>By specifying an empty list of origins, the specified features will be
+    disabled for all browsing contexts, regardless of their origin.</p>
+  </div>
+  <div class="example">
+    <p>SecureCorp Inc. wants to disable use of Geolocation API within all
+    browsing contexts except for its own origin and those whose origin is
+    "<code>https://example.com</code>". It can do so by delivering the
+    following HTTP response header to define a feature policy:</p>
+    <pre>
+      <a href="#feature-policy-header">Feature-Policy</a>: {"<a>geolocation</a>": ["self", "https://example.com"]}</pre>
+    <p>The <a>allowlist</a> is a list of one or more origins, which can include
+    the application's origin, optionally with the keyword "<code>self</code>",
+    and any third-party origin.</p>
+  </div>
+  <div class="example">
+    <p>SecureCorp Inc. is hosting an application on
+    "<code>https://example.com</code>" and wants to disable camera and
+    microphone input on its own origin but enable it for a whitelisted embedee
+    ("<code>https://other.com</code>"). It can do so by delivering the
+    following HTTP response header to define a feature policy:</p>
+    <pre><a href="#feature-policy-header">Feature-Policy</a>: {"<a>camera</a>": ["https://other.com"], "<a>microphone</a>": ["https://other.com"]}</pre>
+    <p>Some features are disabled by default in embedded contexts. The enable
+    policy allows the application to selectively enable such features for
+    whitelisted origins.</p>
+  </div>
+  <div class="example">
+    <p>FastCorp Inc. wants to disable geolocation for all cross-origin child
+    frames, except for a specific iframe. It can do so by delivering the
+    following HTTP response header to define a feature policy:</p>
+    <pre><a href="#feature-policy-header">Feature-Policy</a>: {"<a>geolocation</a>": ["self"]}</pre>
+    <p>and including an "<code>allow</code>" attribute on the iframe
+    element:</p>
+    <pre>&lt;iframe src="https://other.com/map" <a href="#iframe-allow-attribute">allow</a>="<a>geolocation</a>"&gt;&lt;/iframe&gt;</pre>
+    <p>Iframe attributes can selectively enable features in certain frames, and
+    not in others, even if those contain documents from the same origin.</p>
+  </div>
+</section>
+<section>
+  <h2 id="other-and-related-mechanisms">Other and related mechanisms</h2>
+  <p>[[HTML5]] defines a <{iframe/sandbox}> attribute for <{iframe}> elements
+  that allows developers to reduce the risk of including potentially untrusted
+  content by imposing restrictions on content's abilities - e.g. prevent it
+  from submitting forms, running scripts and plugins, and more. The
+  [=sandbox=] directive defined by [[CSP2]] extends this capability to any
+  resource, framed or not, to ask for the same set of restrictions - e.g. via an
+  HTTP response header (<code>Content-Security-Policy: sandbox</code>). These
+  mechanisms enable the developer to:</p>
+  <ul>
+    <li>Set and customize a sandbox policy on any resource via CSP.</li>
+    <li>Set and customize individual sandbox policies on each
+    <code>iframe</code> element within their application.</li>
+  </ul>
+  <p>However, there are several limitations to the above mechanism: the
+  developer cannot automatically apply a policy across all contexts, which
+  makes it hard or impossible to enforce consistently in some cases (e.g. due
+  to third-party content injecting frames, which the developer does not
+  control); there is no mechanism to selectively enable features that may be
+  off by default; the sandbox mechanism uses a whietlist approach which is
+  impossible to extend without compatibility risk.</p>
+  <p>Feature Policy is intended to be used in combination with the sandbox
+  mechanism (i.e. it does not duplicate feature controls already covered by
+  sandbox), and provides an extensible mechanism that addresses the above
+  limitations.</p>
+</section>
+<section>
+  <h2 id="framwork">Framework</h2>
+  <section>
+    <h3 id="features">Features</h3>
+    <p>A <dfn>feature</dfn> controlled by this framework is an API or behaviour
+    which can be enabled or disabled in a document or web worker by referring to
+    it in a <a>feature policy</a>.
+    <p><a>Features</a> have a <dfn>feature name</dfn> keyword, which is a token
+    used in <a>policy directives</a>, and a <a>default allowlist</a>, which
+    defines whether the <a>feature</a> is available to top-level documents, and
+    how access to that feature is inherited by cross-origin frames.</p>
+    <p>A user agent has a set of <dfn>supported features</dfn>, which is the set
+    of <a>features</a> which it allows to be controlled through policies. User
+    agents are not required to support every <a>feature</a>.</p>
+    <p><a>Features</a> themselves are not themselves part of this framework. A
+    non-normative list of currently-defined features is included as an appendix
+    to this specification.
+  </section>
+  <section>
+    <h3 id="policies">Policies</h3>
+    <p>A {{Document}} or {{WorkerGlobalScope}} has a <dfn>feature policy</dfn>,
+    which consists of:</p>
+    <ul>
+      <li>A set of <a data-lt="inherited policy set">inherited policies</a>.
+      </li>
+      <li>A <a data-lt="declared policy">declared policy</a>.
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 id="inherited-policies">Inherited policies</h3>
+    <p>Each document in a frame tree inherits a set of policies from its parent
+    frame, or in the case of the top-level document, from the defined defaults
+    for each feature. This inherited policy set determines the initial state
+    (enabled or disabled) of each feature, and whether it can be controlled by
+    a <a>declared policy</a> in the document.</p>
+    <p>In a {{Document}} in a [=top-level browsing context=], or in a
+    {{WorkerGlobalScope}}, the inherited feature set is based on defined
+    defaults for each feature.</p>
+    <p>In a {{Document}} in a [=nested browsing context=], the inherited feature
+    set is based on the parent document's feature policy, as well as any
+    <a href="#iframe-allow-attribute">allow attributes</a> defined on the
+    browsing context container.</p>
+    <p>An <dfn data-lt="inherited policy|inherited policies">inherited
+    policy</dfn> for a <a>feature</a> is a boolean associated with that feature
+    in a Document or WorkerGlobalScope. It can take the value Enabled or
+    Disabled.</p>
+    <p>An <dfn>inherited policy set</dfn> for a {{Document}} or
+    {{WorkerGlobalScope}} is the set of <a>inherited policies</a> for each
+    <a>feature</a> available in that scope.</p>
+  </section>
+  <section>
+    <h3 id="declared-policies">Declared policies</h3>
+    <p>A <dfn data-lt="declared policy|declared feature policy">declared
+    policy</dfn> is a set of <a>policy directives</a>, which may be the empty
+    set.</p>
+    <p>The <a>declared policy</a> is represented in HTTP headers and HTML
+    attributes as a JSON string.</p>
+    <p>A {{Document}} or {{WorkerGlobalScope}} is considered
+    <dfn>feature-policy-aware</dfn> if it has a <a>declared policy</a> delivered
+    via a Feature-Policy HTTP header.</p>
+    <p>A {{Document}} or {{WorkerGlobalScope}} is which is not
+    <a>feature-policy-aware</a> is considered
+    <dfn>feature-policy-oblivious</dfn>.</p>
+  </section>
+  <section>
+    <h3 id="header-policies">Header policies</h3>
+    <p>A <dfn>header policy</dfn> is a declared policy delivered via an HTTP
+    header with the document, or in an HTML meta element in the document's
+    HEAD. These form the document's <a>feature policy</a>'s <a>declared
+    policy</a>.</p>
+  </section>
+  <section>
+    <h3 id="container-policies">Container policies</h3>
+    <p>In addition to the <a>header policy</a>, each frame has a <dfn>container
+    policy</dfn>, which is a <a>policy directive</a>, which may be empty. The
+    <a>container policy</a> can set by attributes on the browsing context
+    container.</p>
+    <p>The <a>container policy</a> for a frame influences the <a>inherited
+    policy</a> of any document loaded into that frame. (See <a href=
+    "#define-inherited-policy"></a>)</p>
+    <div class="note">
+      Currently, the <a>container policy</a> cannot be set directly, but is
+      indirectly set by <code>iframe</code> "<a href=
+      "#iframe-allowfullscreen-attribute"><code>allowfullscreen</code></a>",
+      "<a href=
+      "#iframe-allowpaymentrequest-attribute"><code>allowpaymentrequest</code></a>",
+      and "<a href="#iframe-allow-attribute"><code>allow</code></a>"
+      attributes. Future revisions to this spec may introduce a mechanism to
+      explicitly declare the full <a>container policy</a>.
+    </div>
+  </section>
+  <section>
+    <h3 id="policy-directives">Policy directives</h3>
+    <p>A <dfn data-lt="policy directive|policy directives">policy
+    directive</dfn> is a dictionary, mapping <a>feature names</a> to
+    corresponding <a>allowlists</a> of origins.</p>
+    <p>The following sections define the set of known <a>feature names</a>.
+    Future versions of this document may define additional such names, as user
+    agents ignore policy directives with unrecognized names when parsing the
+    policy.</p>
+  </section>
+  <section>
+    <h3 id="allowlists">Allowlists</h3>
+    <p>A feature policy <dfn lt="allowlist|allowlists">allowlist</dfn> is
+    a set of origins. An <a>allowlist</a> may be <em>empty</em>, in which case
+    it does not match any origin, or it may contain a list of origins, or it
+    may match every origin. When defining an allowlist in a policy, the special
+    origin "self" may be used, which refers to the origin of document which the
+    policy is associated with.</p>
+    <p>An <a>allowlist</a> <dfn>matches</dfn> an origin <var>o</var> if it
+    matches every origin, or if it contains an origin which is
+    [=same origin-domain=] with <var>o</var>.</p>
+  </section>
+  <section>
+    <h3 id="default-allowlists">Default Allowlists</h3>
+    <p>Every feature controlled by policy has a <dfn lt=
+    "default allowlist|default allowlists">default allowlist</dfn>, which is an
+    <a>allowlist</a>. The <a>default allowlist</a> controls the origins which
+    are allowed to access the feature when used in a top-level document with no
+    declared policy, and also determines whether access to a feature is
+    automatically delegated to child documents.</p>
+    <p>Features are currently defined to have one of these three <a>default
+    allowlists</a>:</p>
+    <dl>
+      <dt>["<code>*</code>"]</dt>
+      <dd>The feature is allowed at the top level by default, and when allowed,
+      is allowed by default to documents in child frames.</dd>
+      <dt>["<code>self</code>"]</dt>
+      <dd>The feature is allowed at the top level by default, and when allowed,
+      is allowed by default to same-origin domain documents in child frames,
+      but is disallowed by default in cross-origin documents in child
+      frames.</dd>
+      <dt>[]</dt>
+      <dd>The feature is disallowed at the top level by default, and is also
+      disallowed by default to documents in child frames.</dd>
+    </dl>
+  </section>
+</section>
+<section>
+  <h2 id="serialization">Feature Policy Serialization</h2>
+  <section>
+    <h3 id="json-serialization">JSON serialization</h3>
+    <p>Declared Policies are represented in HTTP headers and in HTML attributes
+    as JSON text [[!RFC7159]].</p>
+    <pre class="railroad">
+    Sequence:
+      T: [
+      ZeroOrMore:
+        Sequence:
+          T: {
+          ZeroOrMore:
+            Sequence:
+              T: "
+              N: feature-name
+              T: ": [
+              ZeroOrMore:
+                Sequence:
+                  T: "
+                  Choice:
+                    N: origin
+                    T: self
+                    T: *
+                  T: "
+                T: ,
+              T: ]
+            T: ,
+          T: }
+        T: ,
+      T: ]
+    </pre>
+    <p><code>origin</code> is the [=ASCII serialization of an origin=].</p>
+    <p><code>feature-name</code> is a JSON string.</p>
+    <div class="note">
+      The string "<code>self</code>" may be used as an origin in an allowlist.
+      When it is used in this way, it will refer to the origin of the document
+      which contains the feature policy.
+    </div>
+    <div class="note">
+      The begin-array and end-array marks ("[" and "]") are semantically part
+      of the JSON representation of the declared policy, but they do not appear
+      in the HTTP headers or meta elements. Those characters are added to the
+      HTTP headers before parsing, so that the entire set of concatenated
+      headers are parsed as a single array.
+    </div>
+  </section>
+</section>
+<section>
+  <h2 id="delivery">Delivery</h2>
+  <section>
+    <h3 id="feature-policy-http-header-field">Feature-Policy HTTP Header
+    Field</h3>
+    <p>The <dfn lt="feature-policy-header">Feature-Policy</dfn> HTTP header
+    field can be used in the [=response=] (server to client) to communicate the
+    <a>feature policy</a> that should be enforced by the client.</p>
+    <p>The header's value is the <a href="#json-serialization"></a> of the
+    elements of the <a>declared policy</a>:</p>
+    <pre class="abnf">
+      FeaturePolicy = 1#json-field-value
+                ; See Section 2 of [[HTTP-JFV]], and Section 2 of [[RFC7159]]
+    </pre>
+    <p>When the user agent receives a <code>Feature-Policy</code> header field,
+    it MUST <a href="#process-response-policy">process</a> and <a>enforce</a>
+    the serialized policy as described in <a href=
+    "#integration-with-html"></a>.</p>
+  </section>
+  <section>
+    <h3 id="feature-policy-meta-element">The <code>meta</code> element</h3>
+    <p>A {{Document}} may deliver a policy via one or more HTML <{meta}>
+    elements whose <{meta/http-equiv}> attributes are an
+    [=ASCII case-insensitive=] match for the string
+    "<code>Feature-Policy</code>". For example:</p>
+    <pre class="example">&lt;meta http-equiv="Feature-Policy" content='{"webrtc": [], "geolocation": ["https://example.com"]}'&gt;</pre>
+    <p>The <code>meta</code> policy is processed as defined in <a href=
+    "#process-meta-policy"></a> and modifications to the
+    <{meta/content}> attribute of a <{meta}> element after the
+    element has been parsed MUST be ignored.</p>
+    <p>To ensure that the policy can be applied before any scripts are able to
+    execute within the {{Document}}'s [=browsing context=], the following
+    restrictions apply to <code>meta</code> policy:</p>
+    <ul>
+      <li>The elements containing the <code>meta</code> policy MUST be
+      serialized completely within the first 1024 bytes of the document.</li>
+      <li>The elements containing the <code>meta</code> policy MUST appear
+        before any <{script}> or <{link}> elements.</li>
+    </ul>
+    <div class="note">
+      Since JSON serialization requires U+0022 QUOTATION MARK as a string
+      delimiter, it is recommended that the <{meta/content}> attribute
+      of the Feature Policy <{meta}> tag be delimited with U+0027 APOSTROPHE, to
+      avoid having to encode JSON delimeters as "<code>&amp;quot;</code>"
+    </div>
+    <div class="issue">
+      TODO: Ensure that inserting this element after scripts can run has no
+      effect.
+    </div>
+  </section>
+  <section>
+    <h3 id="iframe-allow-attribute">The <code>allow</code> attribute of the
+    <code>iframe</code> element</h3>
+    <pre class="idl">
+partial interface HTMLIFrameElement {
+    [CEReactions, SameObject, PutForwards=value] readonly attribute DOMTokenList allow;
+};</pre>
+    <p><{iframe}> elements have an "<code>allow</code>" attribute, which
+    contains an unordered set of unique space-separated tokens that are ASCII
+    case-insensitive. The allowed values are names of features. Unrecognized
+    values must be ignored.</p>
+    <p>When not empty, the "<code>allow</code>" attribute will result in adding
+    an <a>allowlist</a> for each recognized feature to the frame's <a>container
+    policy</a>, when it is contructed.</p>
+    <p>The <a>allowlist</a> will contain a single origin, which is the origin
+    of URL in the iframe's <{iframe/src}> attribute.</p>
+  </section>
+  <section>
+    <h3 id="legacy-attributes">Additional attributes to support legacy
+    features</h3>
+    <p>Some features controlled by Feature Policy have existing iframe
+    attributes defined. This specification redefines these attributes to act as
+    declared policies for the iframe element.</p>
+    <section>
+      <h4 id="iframe-allowfullscreen-attribute">allowfullscreen</h4>
+      <p>The "<code>allowfullscreen</code>" iframe attribute controls access to
+      {{requestFullscreen()}}.</p>
+      <p>If the iframe element has an "<code>allow</code>" attribute whose
+      value contains the token "<code>fullscreen</code>", then the
+      "<code>allowfullscreen</code> attribute should have no effect.</p>
+      <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
+      will result in adding an <a>allowlist</a> of ["<code>*</code>"] for the
+      "fullscreen" feature to the frame's <a>container policy</a>, when it is
+      constructed.</p>
+      <div class="note">
+        This is different from the behaviour of <code>&lt;iframe
+        allow="fullscreen"&gt;</code>, and is for compatibility with existing
+        uses of <code>allowfullscreen</code>. If
+        <code>allow="fullscreen"</code> and <code>allowfullscreen</code> are
+        both present on an iframe element, then the more restrictive allowlist
+        of <code>allow="fullscreen"</code> will be used.
+      </div>
+    </section>
+    <section>
+      <h4 id="iframe-allowpaymentrequest-attribute">allowpaymentrequest</h4>
+      <p>The "<code>allowpaymentrequest</code>" iframe attribute controls
+      access to [=Payment interface=].</p>
+      <p>If the iframe element has an "<code>allow</code>" attribute whose
+      value contains the token "<code>payment</code>", then the
+      "<code>allowpaymentrequest</code> attribute should have no effect.</p>
+      <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
+      iframe will result in adding an <a>allowlist</a> of ["<code>*</code>"] for
+      the "payment" feature to the frame's <a>container policy</a>, when it is
+      constructed.</p>
+      <div class="note">
+        This is different from the behaviour of <code>&lt;iframe
+        allow="payment"&gt;</code>, and is for compatibility with existing uses
+        of <code>allowpaymentrequest</code>. If <code>allow="payment"</code>
+        and <code>allowpaymentrequest</code> are both present on an iframe
+        element, then the more restrictive allowlist of
+        <code>allow="payment"</code> will be used.
+      </div>
+    </section>
+  </section>
+</section>
+<section>
+  <h2 id="integrations">Integrations</h2>
+  <p>This document defines a set of algorithms which other specifications will
+  use in order to implement the restrictions which Feature Policy defines. The
+  integrations are outlined here for clarity, but those external documents are
+  the normative references which ought to be consulted for detailed
+  information.</p>
+  <section>
+    <h3 id="integration-with-html">Integration with HTML</h3>
+    <ol>
+      <li>
+        {{Document}} and {{WorkerGlobalScope}} objects have a
+        <a>Feature Policy</a>, which is populated via the <a href=
+        "#initialize-for-global"></a> algorithm that is called during the
+        "Initialising a new <code>Document</code> object" and "Run a Worker"
+        algorithms.
+      </li>
+      <li>Replace the existing step 12 of "Initialising a new
+      <code>Document</code> object" with the following step:
+        <ul>
+          <li>
+            <a href="#initialize-for-global">Initialize the feature policy</a>
+            for the <code>Document</code>
+          </li>
+        </ul>
+      </li>
+      <li>A <a>feature policy</a> is <dfn data-lt="enforce">enforced</dfn> for
+      a {{Document}} or {{WorkerGlobalScope}} by setting it as the {{Document}}
+      or {{WorkerGlobalScope}}'s <a>Feature Policy</a>.
+      </li>
+      <li>
+        <p>The "[=allowed to use=]" algorithm calls into <a href=
+        "#is-feature-enabled"></a>, as follows:</p>
+        <ol>
+          <li>Replace the current steps #3 and #4 with the following step:
+            <ul>
+              <li>If <code>Document</code>'s <a>feature policy</a> enables the
+              feature indicated by <code>allowattribute</code> for the origin
+              of <code>Document</code>, then return true.
+              </li>
+            </ul>
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <div class="issue">
+      Monkey-patching! As soon as we know that this is the direction we wish to
+      pursue, upstream all of this.
+    </div>
+    <section>
+      <h4 id="process-meta-policy">Process meta policy</h4>
+      <div class="note">
+        This section extends HTML's <code>meta</code> [pragma directives].
+      </div><strong>Feature policy state (http-equiv="feature-policy")</strong>
+      <p>This pragma extends the declared feature policy for a {{Document}}.</p>
+      <ol>
+        <li>If the [meta] element has no [content] attribute, or if that
+        attribute's value is the empty string, then abort these steps.</li>
+        <li>If the [meta] element is not being inserted in into the
+        {{Document}}'s [head] element, or if is inserted after any [script] or
+        [link] elements, then abort these steps.</li>
+        <li>Let document be the meta element's node document</li>
+        <li>Let <var>value</var> be the result of parsing the value of [meta]
+        element's [content] attribute with a [JSON parser].</li>
+        <li>If parsing returns an error, or <var>value</var> is not a [JSON
+        object], then abort these steps.</li>
+        <li>Let <var>directive</var> be the result of running <a href=
+        "#parse-policy-directive"></a> on <var>value</var> and
+        <var ignore>document</var>'s [origin].
+        </li>
+        <li>Run <a href="#merge-directive-with-declared-policy"></a> with <var>
+          directive</var> and document's feature policy's declared policy
+        </li>
+      </ol>
+    </section>
+  </section>
+</section>
+<section>
+  <h2 id="algorithms">Algorithms</h2>
+  <section>
+    <h3 id="process-response-policy">Process response policy</h3>
+    <p>Given a [=response=] (<var>response</var>) and [=global object=]
+    (<var>global</var>), this algorithm returns a <a>declared feature
+    policy</a>.</p>
+    <ol>
+      <li>Abort these steps if the <var>response</var>’s [=header list=] does
+      not contain a [=header=] whose [=name=] is "<code>Feature-Policy</code>".
+      </li>
+      <li>Let <var>header</var> be the concatenation of the [=value=]s of all
+      [=header=] fields in <var>response</var>’s [=header list=] whose name is
+      "<code>Feature-Policy</code>", separated by commas (according to
+      [RFC7230, 3.2.2]).</li>
+      <li>Add a leading "[" U+005B character, and a trailing "]" U+005D
+      character to <var>header</var>.</li>
+      <li>Let <var>feature policy</var> be the result of executing <a href=
+      "#parse-header"></a> on <var>header</var> and <var>global</var>'s origin.
+      </li>
+      <li>Return <var>feature policy</var>.</li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="parse-header">Parse header from <var>value</var> and
+    <var>origin</var></h3>
+    <p>Given a string (<var>value</var>) and an [=origin=] (<var>origin</var>)
+    this algorithm will return a <a>declared feature policy</a>.</p>
+    <ol>
+      <li>Let <var>policy</var> be an empty list.</li>
+      <li>Let <var>list</var> be the result of parsing <var>value</var> with a
+      [=JSON Parser=]. If <var>value</var> cannot be parsed, return
+      <var>policy</var>.</li>
+      <li>Note: If <var>value</var> can be parsed, <var>list</var> must be a
+      valid [=JSON Array=].</li>
+      <li>For each <var>element</var> in <var>list</var>:
+        <ol>
+          <li>If <var>element</var> is not a JSON object, then continue.</li>
+          <li>Let <var>directive</var> be the result of executing <a href=
+          "#parse-policy-directive"></a> on <var>element</var> and
+          <var>origin</var>
+          </li>
+          <li>Run <a href="#merge-directive-with-declared-policy"></a> on <var>
+            directive</var> and <var>policy</var>.
+          </li>
+        </ol>
+      </li>
+      <li>Return <var>policy</var>.</li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="parse-policy-directive">Parse policy directive from
+    <var>value</var> and <var>origin</var></h3>
+    <p>Given a JSON object (<var>value</var>) and an [=origin=]
+    (<var>origin</var>) this algorithm will return a <a>policy
+    directive</a>.</p>
+    <ol>
+      <li>Let <var>directive</var> be a new dictionary, mapping features to
+        <a>allowlist</a>s.
+      </li>
+      <li>For each <var>key</var> and associated <var>targetlist</var> in
+        <var>value</var>:
+        <ol>
+          <li>If <var>key</var> is not equal to the name of any recognized
+          feature, then continue.</li>
+          <li>Let <var>feature</var> be the feature named by
+          <var>key</var>.</li>
+          <li>If <var>targetlist</var> is not an array, then continue.</li>
+          <li>Let <var>allowlist</var> be a new <a>allowlist</a>.
+          </li>
+          <li>If <var>targetlist</var> contains the string "<code>*</code>",
+          set <var>allowlist</var> to match every origin.</li>
+          <li>Otherwise, for each <var>element</var> in <var>targetlist</var>:
+            <ol>
+              <li>If <var>element</var> is an ASCII case-insensitive match for
+              "<code>self</code>", let result be <var>origin</var>.</li>
+              <li>Otherwise, let <var>result</var> be the result of executing
+              the URL parser on <var>element</var>.</li>
+              <li>If <var>result</var> is not failure:
+                <ol>
+                  <li>Let <var>target</var> be the origin of
+                  <var>result</var>.</li>
+                  <li>If <var>target</var> is not an opaque origin, append
+                  <var>target</var> to <var>allowlist</var>.</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>Insert <var>allowlist</var> into <var>directive</var> as the
+          value for the key <var>feature</var>.</li>
+        </ol>
+      </li>
+      <li>Return <var>directive</var></li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="merge-directive-with-declared-policy">Merge directive with declared
+    policy</h3>
+    <p>Given a policy direcive (<var>directive</var>) and a declared policy
+    (<var>policy</var>), this algorithm will modify <var>policy</var> to
+    account for the new directive.</p>
+    <ol>
+      <li>For each <var>feature</var> and associated <var>allowlist</var> in
+      <var>directive</var>:
+        <ol>
+          <li>If <var>policy</var> does not contain an allowlist for
+          <var>feature</var>, then add <var>allowlist</var> to
+          <var>policy</var> as the allowlist for <var>feature</var>.</li>
+        </ol>
+      </li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="process-feature-policy-attributes">Process feature policy
+    attributes</h3>
+    <p>Given an element <var>element</var>, this algorithm returns a
+    <a>declared feature policy</a>, which may be empty.</p>
+    <ol>
+      <li>Let <var>policy</var> be a new <a>policy directive</a>.
+      </li>
+      <li>Let <var>valid-features</var> be the result of running <a href=
+      "#parse-allow-attribute">Parse allow attribute</a> on the value of
+        <var>element</var>'s <code>allow</code> attribute.
+      </li>
+      <li>For each <var>feature</var> in <var>valid-features</var>:
+        <ol>
+          <li>If <var>policy</var> does not contain an allowlist for
+          <var>feature</var>:
+            <ol>
+              <li>Construct a new declaration for <var>feature</var>, whose
+              allowlist is <var>origin</var>.</li>
+              <li>Add <var>declaration</var> to <var>policy</var>.</li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+      <li>If <var>element</var> is an <{iframe}> element:
+        <ol>
+          <li>If <var>element</var>'s <code>allowfullscreen</code> attribute is
+          specified, and <var>policy</var> does not contain an allowlist for
+            <a>fullscreen</a>,
+            <ol>
+              <li>Construct a new declaration for <a>fullscreen</a>, whose
+              allowlist matches all origins.
+              </li>
+              <li>Add <var>declaration</var> to <var>policy</var>.</li>
+            </ol>
+          </li>
+          <li>If <var>element</var>'s <code>allowpaymentrequest</code>
+          attribute is specified, and <var>policy</var> does not contain an
+          allowlist for <a>payment</a>,
+            <ol>
+              <li>Construct a new declaration for <a>payment</a>, whose
+              allowlist matches all origins.
+              </li>
+              <li>Add <var>declaration</var> to <var>policy</var>.</li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+      <li>Return <var>policy</var>.</li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="parse-allow-attribute">Parse allow attribute</h3>
+    <p>Given a <var>list</var>, this algorithm returns a list of <a>feature
+    name keywords</a>, which may be empty.</p>
+    <ol>
+      <li>Let <var>valid-features</var> be an empty list.</li>
+      <li>If <var>list</var> is <code>null</code> or empty, return
+      <var>valid-features</var>.</li>
+      <li>For each <var>item</var> in <var>list</var>:
+        <ol>
+          <li>Convert <var>item</var> to ASCII-lowercase.</li>
+          <li>If <var>item</var> matches a defined <a>feature name</a> which is
+          not present in <var>valid-features</var>,
+            <ol>
+              <li>Append <var>item</var> to <var>valid-features</var>.</li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+      <li>Return <var>valid-features</var>.</li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="initialize-for-global">Initialize <var>global</var>'s Feature
+    Policy from <var>response</var></h3>
+    <p>Given a [=response=] (<var>response</var>) and a global object
+    (<var>global</var>), this algorithm populates <var>global</var>'s
+    <a>Feature Policy</a></p>
+    <ol>
+      <li>Let <var>inherited policies</var> be a new ordered map.</li>
+      <li>Let <var>declared policies</var> be a new ordered map.</li>
+      <li>For each <var>feature</var> supported,
+        <ol>
+          <li>Let <var>isInherited</var> be the result of running <a href=
+          "#define-inherited-policy"></a> on <var>feature</var> and
+          <var>global</var>.
+          </li>
+          <li>Set <var>inherited policies</var>[<var>feature</var>] to
+            <var>isInherited</var>.</li>
+        </ol>
+      </li>
+      <li>Let <var>d</var> be the result of executing <a href=
+      "#process-response-policy"></a> on <var>response</var> and
+      <var>global</var>.
+      </li>
+      <li>For each <var>directive</var> in <var>d</var>:
+        <ol>
+          <li>If <var>inherited policies</var>[ in <var>inherited policies</var> for
+          <var>directive</var>'s feature is true, then append <var>d</var> to
+          <var>declared policies</var></li>
+        </ol>
+      </li>
+      <li>Let <var>policy</var> be a new <a>feature policy</a>, with inherited
+      policy set <var>inherited policies</var> and declared policy set <var>declared policies</var>.
+      </li>
+      <li>
+        <a>Enforce</a> the policy <var>policy</var>.
+      </li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="define-inherited-policy">Define an inherited policy for
+    <var>feature</var></h3>
+    <p>Given a string (<var>feature</var>) and a browsing context
+    (<var>context</var>), this algorithm returns the <a>inherited policy</a>
+    for that feature.</p>
+    <ol>
+      <li>If <var>context</var> is a [=nested browsing context=]:
+        <ol>
+          <li>Let <var>parent</var> be <var>context</var>'s parent browsing
+          context's active document.</li>
+          <li>Let <var>origin</var> be <var>parent</var>'s [=origin=]</li>
+          <li>Let <var>container policy</var> be the result of running
+            <a href="#process-feature-policy-attributes"></a> on
+            <var>context</var>'s browsing context container.
+          </li>
+          <li>If <var>feature</var> is a key in <var>container policy</var>:
+            <ol>
+              <li>If the <a>allowlist</a> for <var>feature</var> in
+              <var>container policy</var> <a>matches</a> <var>origin</var>, and
+              <var>parent</var>'s <a>inherited policy</a> for
+              <var>feature</var> is Enabled, return Enabled.
+              </li>
+              <li>Otherwise return Disabled.</li>
+            </ol>
+          </li>
+          <li>Otherwise, if feature is allowed by <var>parent</var>’s
+          <a>feature policy</a> for <var>origin</var>, return Enabled.
+          </li>
+          <li>Otherwise, return Disabled.</li>
+        </ol>
+      </li>
+      <li>Otherwise, return Enabled.</li>
+    </ol>
+  </section>
+  <section>
+    <h3 id="is-feature-enabled">Is <var>feature</var> enabled in
+    <var>global</var> for <var>origin</var>?</h3>
+    <p>Given a string (<var>feature</var>) and a global object
+    (<var>global</var>), and an [=origin=] (<var>origin</var>), this algorithm
+    returns "<code>Disabled</code>" if <var>feature</var> should be considered
+    disabled, and "<code>Enabled</code>" otherwise.</p>
+    <ol>
+      <li>Let <var>policy</var> be <var>global</var>'s <a>Feature Policy</a>
+      </li>
+      <li>If <var>policy</var>'s <a>inherited policy</a> for <var>feature</var>
+      is Disabled, return "<code>Disabled</code>".</li>
+      <li>If <var>feature</var> is present in <var>policy</var>'s <a>declared
+      policy</a>:
+        <ol>
+          <li>If the <a>allowlist</a> for <var>feature</var> in
+          <var>policy</var>'s <a>declared policy</a> <a>matches</a>
+          <var>origin</var>, then return "<code>Enabled</code>".
+          </li>
+          <li>Otherwise return "<code>Disabled</code>".</li>
+        </ol>
+      </li>
+      <li>If <var>feature</var>'s <a>default allowlist</a> is
+      <code>["*"]</code>, return "<code>Enabled</code>".
+      </li>
+      <li>If <var>feature</var>'s <a>default allowlist</a> is
+      <code>["self"]</code>, and <var>origin</var> is [=same origin-domain=]
+      with <var>global</var>'s active document's origin, return
+      "<code>Enabled</code>".
+      </li>
+      <li>Return "<code>Disabled</code>".</li>
+    </ol>
+  </section>
+</section>
+<section>
+  <h2 id="iana-considerations">IANA Considerations</h2>
+  <p>The permanent message header field registry should be updated with the
+  following registration [[!RFC3864]]:</p>
+  <dl>
+    <dt>Header field name</dt>
+    <dd>Feature-Policy</dd>
+    <dt>Applicable protocol</dt>
+    <dd>http</dd>
+    <dt>Status</dt>
+    <dd>standard</dd>
+    <dt>Author/Change controller</dt>
+    <dd>W3C</dd>
+    <dt>Specification document</dt>
+    <dd>
+      <a href="">Feature Policy API</a>
+    </dd>
+  </dl>
+</section>
+<section id="privacy" class="informative">
+  <h2 id="privacy-and-security">Privacy and Security</h2>
+  <p class="issue">TODO</p>
+</section>
+<section class="appendix">
+  <h2 id="defined-features">Appendix A: Features</h2>
+  <p>This appendix is a reference to currently-defined valid <a data-lt=
+  "feature">features</a>, their <a>feature name</a> keywords, and their effect
+  effect when applied via a <a data-lt="policy directive">directive</a> as part
+  of a <a>feature policy</a>. This reference is non-normative; the actual
+  definitions are given in subsections below.</p>
+  <div class="issue">
+    As soon as possible, move the definitions to their respective controlling
+    specifications, and link to those specifications from this one. This spec
+    shouldn't be required to enumerate every feature.
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Feature name</th>
+        <th>
+          <a>Default allowlist</a>
+        </th>
+        <th>Brief description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a>camera</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls access to video input devices.</td>
+      </tr>
+      <tr>
+        <td>
+          <a>eme</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls whether {{requestMediaKeySystemAccess()}} is allowed.</td>
+      </tr>
+      <tr>
+        <td>
+          <a>fullscreen</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls whether {{requestFullscreen()}} is allowed.</td>
+      </tr>
+      <tr>
+        <td>
+          <a>geolocation</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls access to [=Geolocation interface=].</td>
+      </tr>
+      <tr>
+        <td>
+          <a>microphone</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls access to audio input devices.</td>
+      </tr>
+      <tr>
+        <td>
+          <a>midi</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls access to {{requestMIDIAccess()}} method.</td>
+      </tr>
+      <tr>
+        <td>
+          <a>payment</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls access to [=PaymentRequest interface=].</td>
+      </tr>
+      <tr>
+        <td>
+          <a>speaker</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls access to audio output devices.</td>
+      </tr>
+      <tr>
+        <td>
+          <a>vibrate</a>
+        </td>
+        <td><code>self</code></td>
+        <td>Controls access to {{vibrate()}} method.</td>
+      </tr>
+    </tbody>
+  </table>
+  <section>
+    <h3 id="feature-definitions">Feature Definitions</h3>
+    <section>
+      <h4 id="camera-feature">camera</h4>
+      <p>The <dfn>camera</dfn> feature controls access to video input devices
+      requested through the [=NavigatorUserMedia interface=]
+      ([[MEDIACAPTURE-API]]).</p>
+      <p>If disabled in a document, then calls to getUserMedia() MUST NOT grant
+      access to video input devices in that document.</p>
+      <p>The <a>feature name</a> for <a>camera</a> is "<code>camera</code>"</p>
+      <p>The <a>default allowlist</a> for <a>camera</a> is
+      <code>["self"]</code>.</p>
+    </section>
+    <section>
+      <h4 id="eme-feature">eme</h4>
+      <p>The <dfn>eme</dfn> keyword controls whether encrypted media extensions
+      [[encrypted-media]] are available.</p>
+      <p>If disabled in a document, the promise returned by
+      {{requestMediaKeySystemAccess()}} must reject with a NotSupportedError.
+      </p>
+      <p>The <a>feature name</a> for <a>eme</a> is "<code>eme</code>"</p>
+      <p>The <a>default allowlist</a> for <a>eme</a> is
+      <code>["self"]</code>.</p>
+    </section>
+    <section>
+      <h4 id="fullscreen-feature">fullscreen</h4>
+      <p>The <dfn>fullscreen</dfn> keyword controls whether the
+      {{requestFullscreen()}} method ([[WHATWG-FULLSCREEN]]) is allowed to
+      request fullscreen.</p>
+      <p>If disabled in any document, the document will not be allowed to use
+      fullscreen. If enabled, the document will be allowed to use
+      fullscreen.</p>
+      <p>The <a>feature name</a> for <a>fullscreen</a> is
+      "<code>fullscreen</code>"</p>
+      <p>The <a>default allowlist</a> for <a>fullscreen</a> is
+      <code>["self"]</code>.</p>
+    </section>
+    <section>
+      <h4 id="geolocation-feature">geolocation</h4>
+      <p>The <dfn>geolocation</dfn> keyword controls whether the current
+      document is alowed to use the [=Geolocation interface=]
+      ([[GEOLOCATION-API]]).</p>
+      <p>If disabled in any document, calls to both getCurrentPosition and
+      watchPosition must result in the error callback being invoked with
+      PERMISSION_DENIED.</p>
+      <p>The <a>feature name</a> for <a>geolocation</a> is
+      "<code>geolocation</code>"</p>
+      <p>The <a>default allowlist</a> for <a>geolocation</a> is
+      <code>["self"]</code>.</p>
+    </section>
+    <section>
+      <h4 id="microphone-feature">microphone</h4>
+      <p>The <dfn>microphone</dfn> feature controls access to audio input
+      devices requested through the [=NavigatorUserMedia interface=]
+      ([[MEDIACAPTURE-API]]).</p>
+      <p>If disabled in a document, then calls to getUserMedia() MUST NOT grant
+      access to audio input devices in that document.</p>
+      <p>The <a>feature name</a> for <a>microphone</a> is "<code>microphone</code>"
+      </p>
+      <p>The <a>default allowlist</a> for <a>microphone</a> is
+      <code>["self"]</code>.</p>
+    </section>
+    <section>
+      <h4 id="midi-feature">midi</h4>
+      <p>The <dfn>midi</dfn> keyword controls whether the current document is
+      allowed to use the {{requestMIDIAccess()}} method ([[WEBMIDI]]).</p>
+      <p>If disabled in a document, the promise returned by requestMIDIAccess
+      must reject with a DOMException parameter.</p>
+      <p>The <a>feature name</a> for <a>midi</a> is "<code>midi</code>"
+      </p>
+      <p>The <a>default allowlist</a> for <a>midi</a> is
+      <code>["self"]</code>.</p>
+    </section>
+    <section>
+      <h4 id="payment-feature">payment</h4>
+      <p>The <dfn>payment</dfn> feature controls whether the current document
+      is allowed to use the [=PaymentRequest interface=]
+      ([[PAYMENT-REQUEST]]).</p>
+      <p>If disabled in a document, then calls to the PaymentRequest constuctor
+      MUST throw a SecurityError.</p>
+      <p>The <a>feature name</a> for payment is "<code>payment</code>"</p>
+      <p>The <a>default allowlist</a> for <a>payment</a> is
+      <code>["self"]</code>.</p>
+    </section>
+    <section>
+      <h4 id="speaker-feature">speaker</h4>
+      <p>The <dfn>speaker</dfn> feature controls access to audio output devices
+      requested through the [=NavigatorUserMedia interface=]
+      ([[audio-output]]).</p>
+      <p>If disabled in a document, then calls to getUserMedia() MUST NOT grant
+      access to audio output devices in that document.</p>
+      <p>The <a>feature name</a> for <a>speaker</a> is "<code>speaker</code>"
+      </p>
+      <p>The <a>default allowlist</a> for <a>speaker</a> is
+      <code>["self"]</code>.</p>
+    </section>
+    <section>
+      <h4 id="vibrate-feature">vibrate</h4>
+      <p>The <dfn>vibrate</dfn> feature controls whether the {{vibrate()}}
+      method ([[VIBRATION]]) is allowed to cause device vibration.</p>
+      <p>If disabled in a document, then calls to the {{vibrate()}} method
+      should silently do nothing. If enabled, the browser may allow the device
+      to vibrate.</p>
+      <p>The <a>feature name</a> for <a>vibrate</a> is "<code>vibrate</code>"
+      </p>
+      <p>The <a>default allowlist</a> for <a>vibrate</a> is
+      <code>["self"]</code>.</p>
+    </section>
+  </section>
+</section>

--- a/index.bs
+++ b/index.bs
@@ -388,7 +388,7 @@ partial interface HTMLIFrameElement {
       {{requestFullscreen()}}.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>fullscreen</code>", then the
-      "<code>allowfullscreen</code> attribute should have no effect.</p>
+      "<code>allowfullscreen</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
       will result in adding an <a>allowlist</a> of ["<code>*</code>"] for the
       "fullscreen" feature to the frame's <a>container policy</a>, when it is
@@ -408,7 +408,7 @@ partial interface HTMLIFrameElement {
       access to [=Payment interface=].</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>payment</code>", then the
-      "<code>allowpaymentrequest</code> attribute should have no effect.</p>
+      "<code>allowpaymentrequest</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
       iframe will result in adding an <a>allowlist</a> of ["<code>*</code>"] for
       the "payment" feature to the frame's <a>container policy</a>, when it is

--- a/index.bs
+++ b/index.bs
@@ -190,9 +190,8 @@ spec:fetch; type:dfn; text:value
   <section>
     <h3 id="header-policies">Header policies</h3>
     <p>A <dfn>header policy</dfn> is a declared policy delivered via an HTTP
-    header with the document, or in an HTML meta element in the document's
-    HEAD. These form the document's <a>feature policy</a>'s <a>declared
-    policy</a>.</p>
+    header with the document. This forms the document's <a>feature policy</a>'s
+    <a>declared policy</a>.</p>
   </section>
   <section>
     <h3 id="container-policies">Container policies</h3>
@@ -303,9 +302,9 @@ spec:fetch; type:dfn; text:value
     <div class="note">
       The begin-array and end-array marks ("[" and "]") are semantically part
       of the JSON representation of the declared policy, but they do not appear
-      in the HTTP headers or meta elements. Those characters are added to the
-      HTTP headers before parsing, so that the entire set of concatenated
-      headers are parsed as a single array.
+      in the HTTP headers. Those characters are added to the HTTP headers before
+      parsing, so that the entire set of concatenated headers are parsed as a
+      single array.
     </div>
   </section>
 </section>
@@ -327,37 +326,6 @@ spec:fetch; type:dfn; text:value
     it MUST <a href="#process-response-policy">process</a> and <a>enforce</a>
     the serialized policy as described in <a href=
     "#integration-with-html"></a>.</p>
-  </section>
-  <section>
-    <h3 id="feature-policy-meta-element">The <code>meta</code> element</h3>
-    <p>A {{Document}} may deliver a policy via one or more HTML <{meta}>
-    elements whose <{meta/http-equiv}> attributes are an
-    [=ASCII case-insensitive=] match for the string
-    "<code>Feature-Policy</code>". For example:</p>
-    <pre class="example">&lt;meta http-equiv="Feature-Policy" content='{"webrtc": [], "geolocation": ["https://example.com"]}'&gt;</pre>
-    <p>The <code>meta</code> policy is processed as defined in <a href=
-    "#process-meta-policy"></a> and modifications to the
-    <{meta/content}> attribute of a <{meta}> element after the
-    element has been parsed MUST be ignored.</p>
-    <p>To ensure that the policy can be applied before any scripts are able to
-    execute within the {{Document}}'s [=browsing context=], the following
-    restrictions apply to <code>meta</code> policy:</p>
-    <ul>
-      <li>The elements containing the <code>meta</code> policy MUST be
-      serialized completely within the first 1024 bytes of the document.</li>
-      <li>The elements containing the <code>meta</code> policy MUST appear
-        before any <{script}> or <{link}> elements.</li>
-    </ul>
-    <div class="note">
-      Since JSON serialization requires U+0022 QUOTATION MARK as a string
-      delimiter, it is recommended that the <{meta/content}> attribute
-      of the Feature Policy <{meta}> tag be delimited with U+0027 APOSTROPHE, to
-      avoid having to encode JSON delimeters as "<code>&amp;quot;</code>"
-    </div>
-    <div class="issue">
-      TODO: Ensure that inserting this element after scripts can run has no
-      effect.
-    </div>
   </section>
   <section>
     <h3 id="iframe-allow-attribute">The <code>allow</code> attribute of the
@@ -473,32 +441,6 @@ partial interface HTMLIFrameElement {
       Monkey-patching! As soon as we know that this is the direction we wish to
       pursue, upstream all of this.
     </div>
-    <section>
-      <h4 id="process-meta-policy">Process meta policy</h4>
-      <div class="note">
-        This section extends HTML's <code>meta</code> [pragma directives].
-      </div><strong>Feature policy state (http-equiv="feature-policy")</strong>
-      <p>This pragma extends the declared feature policy for a {{Document}}.</p>
-      <ol>
-        <li>If the [meta] element has no [content] attribute, or if that
-        attribute's value is the empty string, then abort these steps.</li>
-        <li>If the [meta] element is not being inserted in into the
-        {{Document}}'s [head] element, or if is inserted after any [script] or
-        [link] elements, then abort these steps.</li>
-        <li>Let document be the meta element's node document</li>
-        <li>Let <var>value</var> be the result of parsing the value of [meta]
-        element's [content] attribute with a [JSON parser].</li>
-        <li>If parsing returns an error, or <var>value</var> is not a [JSON
-        object], then abort these steps.</li>
-        <li>Let <var>directive</var> be the result of running <a href=
-        "#parse-policy-directive"></a> on <var>value</var> and
-        <var ignore>document</var>'s [origin].
-        </li>
-        <li>Run <a href="#merge-directive-with-declared-policy"></a> with <var>
-          directive</var> and document's feature policy's declared policy
-        </li>
-      </ol>
-    </section>
   </section>
 </section>
 <section>

--- a/index.html
+++ b/index.html
@@ -1488,24 +1488,19 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <ol class="toc">
       <li><a href="#feature-policy-http-header-field"><span class="secno">6.1</span> <span class="content">Feature-Policy HTTP Header
     Field</span></a>
-      <li><a href="#feature-policy-meta-element"><span class="secno">6.2</span> <span class="content">The <code>meta</code> element</span></a>
-      <li><a href="#iframe-allow-attribute"><span class="secno">6.3</span> <span class="content">The <code>allow</code> attribute of the <code>iframe</code> element</span></a>
+      <li><a href="#iframe-allow-attribute"><span class="secno">6.2</span> <span class="content">The <code>allow</code> attribute of the <code>iframe</code> element</span></a>
       <li>
-       <a href="#legacy-attributes"><span class="secno">6.4</span> <span class="content">Additional attributes to support legacy
+       <a href="#legacy-attributes"><span class="secno">6.3</span> <span class="content">Additional attributes to support legacy
     features</span></a>
        <ol class="toc">
-        <li><a href="#iframe-allowfullscreen-attribute"><span class="secno">6.4.1</span> <span class="content">allowfullscreen</span></a>
-        <li><a href="#iframe-allowpaymentrequest-attribute"><span class="secno">6.4.2</span> <span class="content">allowpaymentrequest</span></a>
+        <li><a href="#iframe-allowfullscreen-attribute"><span class="secno">6.3.1</span> <span class="content">allowfullscreen</span></a>
+        <li><a href="#iframe-allowpaymentrequest-attribute"><span class="secno">6.3.2</span> <span class="content">allowpaymentrequest</span></a>
        </ol>
      </ol>
     <li>
      <a href="#integrations"><span class="secno">7</span> <span class="content">Integrations</span></a>
      <ol class="toc">
-      <li>
-       <a href="#integration-with-html"><span class="secno">7.1</span> <span class="content">Integration with HTML</span></a>
-       <ol class="toc">
-        <li><a href="#process-meta-policy"><span class="secno">7.1.1</span> <span class="content">Process meta policy</span></a>
-       </ol>
+      <li><a href="#integration-with-html"><span class="secno">7.1</span> <span class="content">Integration with HTML</span></a>
      </ol>
     <li>
      <a href="#algorithms"><span class="secno">8</span> <span class="content">Algorithms</span></a>
@@ -1718,9 +1713,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="4.5" id="header-policies"><span class="secno">4.5. </span><span class="content">Header policies</span><a class="self-link" href="#header-policies"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="header-policy">header policy</dfn> is a declared policy delivered via an HTTP
-    header with the document, or in an HTML meta element in the document’s
-    HEAD. These form the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-2">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-5">declared
-    policy</a>.</p>
+    header with the document. This forms the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-2">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-5">declared policy</a>.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.6" id="container-policies"><span class="secno">4.6. </span><span class="content">Container policies</span><a class="self-link" href="#container-policies"></a></h3>
@@ -2043,9 +2036,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       which contains the feature policy. </div>
      <div class="note" role="note"> The begin-array and end-array marks ("[" and "]") are semantically part
       of the JSON representation of the declared policy, but they do not appear
-      in the HTTP headers or meta elements. Those characters are added to the
-      HTTP headers before parsing, so that the entire set of concatenated
-      headers are parsed as a single array. </div>
+      in the HTTP headers. Those characters are added to the HTTP headers before
+      parsing, so that the entire set of concatenated headers are parsed as a
+      single array. </div>
     </section>
    </section>
    <section>
@@ -2064,30 +2057,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     it MUST <a href="#process-response-policy">process</a> and <a data-link-type="dfn" href="#enforce" id="ref-for-enforce-1">enforce</a> the serialized policy as described in <a href="#integration-with-html">§7.1 Integration with HTML</a>.</p>
     </section>
     <section>
-     <h3 class="heading settled" data-level="6.2" id="feature-policy-meta-element"><span class="secno">6.2. </span><span class="content">The <code>meta</code> element</span><a class="self-link" href="#feature-policy-meta-element"></a></h3>
-     <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> may deliver a policy via one or more HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> elements whose <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a></code> attributes are an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for the string
-    "<code>Feature-Policy</code>". For example:</p>
-<pre class="example" id="example-64676863"><a class="self-link" href="#example-64676863"></a>&lt;meta http-equiv="Feature-Policy" content='{"webrtc": [], "geolocation": ["https://example.com"]}'></pre>
-     <p>The <code>meta</code> policy is processed as defined in <a href="#process-meta-policy">§7.1.1 Process meta policy</a> and modifications to the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">content</a></code> attribute of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element after the
-    element has been parsed MUST be ignored.</p>
-     <p>To ensure that the policy can be applied before any scripts are able to
-    execute within the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>, the following
-    restrictions apply to <code>meta</code> policy:</p>
-     <ul>
-      <li>The elements containing the <code>meta</code> policy MUST be
-      serialized completely within the first 1024 bytes of the document.
-      <li>The elements containing the <code>meta</code> policy MUST appear
-        before any <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> elements.
-     </ul>
-     <div class="note" role="note"> Since JSON serialization requires U+0022 QUOTATION MARK as a string
-      delimiter, it is recommended that the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">content</a></code> attribute
-      of the Feature Policy <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> tag be delimited with U+0027 APOSTROPHE, to
-      avoid having to encode JSON delimeters as "<code>&amp;quot;</code>" </div>
-     <div class="issue" id="issue-7c854c21"><a class="self-link" href="#issue-7c854c21"></a> TODO: Ensure that inserting this element after scripts can run has no
-      effect. </div>
-    </section>
-    <section>
-     <h3 class="heading settled" data-level="6.3" id="iframe-allow-attribute"><span class="secno">6.3. </span><span class="content">The <code>allow</code> attribute of the <code>iframe</code> element</span><a class="self-link" href="#iframe-allow-attribute"></a></h3>
+     <h3 class="heading settled" data-level="6.2" id="iframe-allow-attribute"><span class="secno">6.2. </span><span class="content">The <code>allow</code> attribute of the <code>iframe</code> element</span><a class="self-link" href="#iframe-allow-attribute"></a></h3>
 <pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmliframeelement">HTMLIFrameElement</a> {
     [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#PutForwards">PutForwards</a>=<a class="n idl-code" data-link-type="attribute" href="https://dom.spec.whatwg.org/#dom-domtokenlist-value">value</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#domtokenlist">DOMTokenList</a> <dfn class="nv idl-code" data-dfn-for="HTMLIFrameElement" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMTokenList" id="dom-htmliframeelement-allow">allow<a class="self-link" href="#dom-htmliframeelement-allow"></a></dfn>;
 };</pre>
@@ -2102,13 +2072,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     of URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-src">src</a></code> attribute.</p>
     </section>
     <section>
-     <h3 class="heading settled" data-level="6.4" id="legacy-attributes"><span class="secno">6.4. </span><span class="content">Additional attributes to support legacy
+     <h3 class="heading settled" data-level="6.3" id="legacy-attributes"><span class="secno">6.3. </span><span class="content">Additional attributes to support legacy
     features</span><a class="self-link" href="#legacy-attributes"></a></h3>
      <p>Some features controlled by Feature Policy have existing iframe
     attributes defined. This specification redefines these attributes to act as
     declared policies for the iframe element.</p>
      <section>
-      <h4 class="heading settled" data-level="6.4.1" id="iframe-allowfullscreen-attribute"><span class="secno">6.4.1. </span><span class="content">allowfullscreen</span><a class="self-link" href="#iframe-allowfullscreen-attribute"></a></h4>
+      <h4 class="heading settled" data-level="6.3.1" id="iframe-allowfullscreen-attribute"><span class="secno">6.3.1. </span><span class="content">allowfullscreen</span><a class="self-link" href="#iframe-allowfullscreen-attribute"></a></h4>
       <p>The "<code>allowfullscreen</code>" iframe attribute controls access to <code class="idl"><a data-link-type="idl">requestFullscreen()</a></code>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>fullscreen</code>", then the
@@ -2124,7 +2094,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         of <code>allow="fullscreen"</code> will be used. </div>
      </section>
      <section>
-      <h4 class="heading settled" data-level="6.4.2" id="iframe-allowpaymentrequest-attribute"><span class="secno">6.4.2. </span><span class="content">allowpaymentrequest</span><a class="self-link" href="#iframe-allowpaymentrequest-attribute"></a></h4>
+      <h4 class="heading settled" data-level="6.3.2" id="iframe-allowpaymentrequest-attribute"><span class="secno">6.3.2. </span><span class="content">allowpaymentrequest</span><a class="self-link" href="#iframe-allowpaymentrequest-attribute"></a></h4>
       <p>The "<code>allowpaymentrequest</code>" iframe attribute controls
       access to <a data-link-type="dfn">Payment interface</a>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
@@ -2177,27 +2147,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      </ol>
      <div class="issue" id="issue-7605d231"><a class="self-link" href="#issue-7605d231"></a> Monkey-patching! As soon as we know that this is the direction we wish to
       pursue, upstream all of this. </div>
-     <section>
-      <h4 class="heading settled" data-level="7.1.1" id="process-meta-policy"><span class="secno">7.1.1. </span><span class="content">Process meta policy</span><a class="self-link" href="#process-meta-policy"></a></h4>
-      <div class="note" role="note"> This section extends HTML’s <code>meta</code> [pragma directives]. </div>
-      <strong>Feature policy state (http-equiv="feature-policy")</strong> 
-      <p>This pragma extends the declared feature policy for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code>.</p>
-      <ol>
-       <li>If the [meta] element has no [content] attribute, or if that
-        attribute’s value is the empty string, then abort these steps.
-       <li>If the [meta] element is not being inserted in into the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code>'s [head] element, or if is inserted after any [script] or
-        [link] elements, then abort these steps.
-       <li>Let document be the meta element’s node document
-       <li>Let <var>value</var> be the result of parsing the value of [meta]
-        element’s [content] attribute with a [JSON parser].
-       <li>If parsing returns an error, or <var>value</var> is not a [JSON
-        object], then abort these steps.
-       <li>Let <var>directive</var> be the result of running <a href="#parse-policy-directive">§8.3 Parse policy directive from
-    value and origin</a> on <var>value</var> and <var>document</var>’s [origin]. 
-       <li>Run <a href="#merge-directive-with-declared-policy">§8.4 Merge directive with declared
-    policy</a> with <var> directive</var> and document’s feature policy’s declared policy 
-      </ol>
-     </section>
     </section>
    </section>
    <section>
@@ -2737,7 +2686,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-htmliframeelement-allow">allow</a><span>, in §6.3</span>
+   <li><a href="#dom-htmliframeelement-allow">allow</a><span>, in §6.2</span>
    <li><a href="#allowlist">allowlist</a><span>, in §4.8</span>
    <li><a href="#allowlist">allowlists</a><span>, in §4.8</span>
    <li><a href="#camera">camera</a><span>, in §Unnumbered section</span>
@@ -2800,25 +2749,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#allowed-to-use">allowed to use</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">ascii serialization of an origin</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">content</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-request-header-list">header list</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">same origin-domain</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-sandbox">sandbox</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-src">src</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
-    <ul>
-     <li><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
     </ul>
    <li>
     <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
@@ -2841,8 +2779,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-   <dt id="biblio-infra">[INFRA]
-   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-rfc3864">[RFC3864]
@@ -2886,8 +2822,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> TODO: Ensure that inserting this element after scripts can run has no
-      effect. <a href="#issue-7c854c21"> ↵ </a></div>
    <div class="issue"> Monkey-patching! As soon as we know that this is the direction we wish to
       pursue, upstream all of this. <a href="#issue-7605d231"> ↵ </a></div>
    <div class="issue">TODO<a href="#issue-b7b1e314"> ↵ </a></div>
@@ -2988,10 +2922,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#container-policy">#container-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-policy-1">4.6. Container policies</a> <a href="#ref-for-container-policy-2">(2)</a> <a href="#ref-for-container-policy-3">(3)</a> <a href="#ref-for-container-policy-4">(4)</a>
-    <li><a href="#ref-for-container-policy-5">6.3. The allow attribute of the
+    <li><a href="#ref-for-container-policy-5">6.2. The allow attribute of the
     iframe element</a>
-    <li><a href="#ref-for-container-policy-6">6.4.1. allowfullscreen</a>
-    <li><a href="#ref-for-container-policy-7">6.4.2. allowpaymentrequest</a>
+    <li><a href="#ref-for-container-policy-6">6.3.1. allowfullscreen</a>
+    <li><a href="#ref-for-container-policy-7">6.3.2. allowpaymentrequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="policy-directive">
@@ -3014,10 +2948,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-allowlist-2">4.7. Policy directives</a>
     <li><a href="#ref-for-allowlist-3">4.8. Allowlists</a> <a href="#ref-for-allowlist-4">(2)</a>
     <li><a href="#ref-for-allowlist-5">4.9. Default Allowlists</a>
-    <li><a href="#ref-for-allowlist-6">6.3. The allow attribute of the
+    <li><a href="#ref-for-allowlist-6">6.2. The allow attribute of the
     iframe element</a> <a href="#ref-for-allowlist-7">(2)</a>
-    <li><a href="#ref-for-allowlist-8">6.4.1. allowfullscreen</a>
-    <li><a href="#ref-for-allowlist-9">6.4.2. allowpaymentrequest</a>
+    <li><a href="#ref-for-allowlist-8">6.3.1. allowfullscreen</a>
+    <li><a href="#ref-for-allowlist-9">6.3.2. allowpaymentrequest</a>
     <li><a href="#ref-for-allowlist-10">8.3. Parse policy directive from
     value and origin</a> <a href="#ref-for-allowlist-11">(2)</a>
     <li><a href="#ref-for-allowlist-12">8.8. Define an inherited policy for

--- a/index.html
+++ b/index.html
@@ -1,1136 +1,3199 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta name="generator" content=
-  "HTML Tidy for HTML5 for Mac OS X version 5.1.25">
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <title>Feature Policy</title>
-  <meta charset='utf-8'>
-  <meta http-equiv="refresh" content="0; url=https://docs.google.com/document/d/1k0Ua-ZWlM_PsFCFdLMa8kaVTo32PeNZ4G7FFHqpFx4E/edit">
-  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class=
-  'remove'>
-  </script>
-  <script class='remove'>
-  var respecConfig = {
-    shortName: "feature-policy",
-    specStatus: "CG-DRAFT",
-    useExperimentalStyles: true,
-    edDraftURI: "http://wicg.github.io/feature-policy/",
-    editors: [{
-      name: "Ilya Grigorik",
-      url: "https://www.igvita.com/",
-      mailto: "igrigorik@gmail.com",
-      company: "Google",
-      companyURL: "https://google.com/",
-      w3cid: "56102"
-    }, {
-      name: "Mike West",
-      mailto: "mkwst@google.com",
-      company: "Google",
-      companyURL: "https://google.com/",
-      w3cid: "56384"
-    }],
-    wg: "WICG",
-    subjectPrefix: "[feature-policy]",
-    format: "markdown",
-    // noLegacyStyle: true,
-    otherLinks: [{
-      key: 'Repository',
-      data: [{
-        value: 'We are on Github.',
-        href: 'https://github.com/wicg/feature-policy/'
-      }, {
-        value: 'File a bug.',
-        href: 'https://github.com/wicg/feature-policy/issues'
-      }, {
-        value: 'Commit history.',
-        href: 'https://github.com/wicg/feature-policy/commits/gh-pages/index.html'
-      }]
-    }],
-    localBiblio:  {
-      'PERMISSION-DELEGATION': {
-        title: 'Permission Delegation To Embedded Web Applications',
-        href: 'https://noncombatant.github.io/permission-delegation-api/',
-        authors: [
-          'Raymes Khoury',
-          'Chris Palmer'
-        ],
-        date: 'March 30 2016'
-      },
-      'HTTP-JFV': {
-        title: 'A JSON Encoding for HTTP Header Field Values',
-        href: 'https://greenbytes.de/tech/webdav/draft-ietf-httpbis-jfv-02.html',
-        authors: [
-          'Julian Reschke'
-        ],
-        date: 'October 24 2016'
-      }
-    }
-  };
-  </script>
-  <style>
-    table {
-      border-collapse: collapse;
-      border-style: hidden hidden none hidden;
-    }
-    table td, table th {
-      border-left: solid;
-      border-right: solid;
-      border-bottom: solid thin;
-      vertical-align: top;
-      padding: 0.2em;
-    }
-    th {
-      background-color: #ccc;
-    }
-  </style>
-</head>
-<body>
-  <section id='abstract'>
-    <p>This specification defines a mechanism that allows developers to
-    selectively enable and disable use of various browser features and
-    APIs.</p>
-  </section>
-  <section id='sotd'>
-    <p class='warning'><strong>This document is outdated</strong>.
-    Please refer to the <a href="https://docs.google.com/document/d/1k0Ua-ZWlM_PsFCFdLMa8kaVTo32PeNZ4G7FFHqpFx4E/edit">explainer</a>.</p>
-  </section>
-  <section>
-    <h2>Introduction</h2>
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+<style data-fill-with="stylesheet">/******************************************************************************
+ *                   Style sheet for the W3C specifications                   *
+ *
+ * Special classes handled by this style sheet include:
+ *
+ * Indices
+ *   - .toc for the Table of Contents (<ol class="toc">)
+ *     + <span class="secno"> for the section numbers
+ *   - #toc for the Table of Contents (<nav id="toc">)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
+ *   - table.index for Index Tables (e.g. for properties or elements)
+ *
+ * Structural Markup
+ *   - table.data for general data tables
+ *     -> use 'scope' attribute, <colgroup>, <thead>, and <tbody> for best results !
+ *     -> use <table class='complex data'> for extra-complex tables
+ *     -> use <td class='long'> for paragraph-length cell content
+ *     -> use <td class='pre'> when manual line breaks/indentation would help readability
+ *   - dl.switch for switch statements
+ *   - ol.algorithm for algorithms (helps to visualize nesting)
+ *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
+ *     -> .sidefigure for right-floated figures
+ *   - ins/del
+ *
+ * Code
+ *   - pre and code
+ *
+ * Special Sections
+ *   - .note       for informative notes             (div, p, span, aside, details)
+ *   - .example    for informative examples          (div, p, pre, span)
+ *   - .issue      for issues                        (div, p, span)
+ *   - .assertion  for assertions                    (div, p, span)
+ *   - .advisement for loud normative statements     (div, p, strong)
+ *   - .annoying-warning for spec obsoletion notices (div, aside, details)
+ *
+ * Definition Boxes
+ *   - pre.def   for WebIDL definitions
+ *   - table.def for tables that define other entities (e.g. CSS properties)
+ *   - dl.def    for definition lists that define other entitles (e.g. HTML elements)
+ *
+ * Numbering
+ *   - .secno for section numbers in .toc and headings (<span class='secno'>3.2</span>)
+ *   - .marker for source-inserted example/figure/issue numbers (<span class='marker'>Issue 4</span>)
+ *   - ::before styled for CSS-generated issue/example/figure numbers:
+ *     -> Documents wishing to use this only need to add
+ *        figcaption::before,
+ *        .caption::before { content: "Figure "  counter(figure) " ";  }
+ *        .example::before { content: "Example " counter(example) " "; }
+ *        .issue::before   { content: "Issue "   counter(issue) " ";   }
+ *
+ * Header Stuff (ignore, just don't conflict with these classes)
+ *   - .head for the header
+ *   - .copyright for the copyright
+ *
+ * Miscellaneous
+ *   - .overlarge for things that should be as wide as possible, even if
+ *     that overflows the body text area. This can be used on an item or
+ *     on its container, depending on the effect desired.
+ *     Note that this styling basically doesn't help at all when printing,
+ *     since A4 paper isn't much wider than the max-width here.
+ *     It's better to design things to fit into a narrower measure if possible.
+ *   - js-added ToC jump links (see fixup.js)
+ *
+ ******************************************************************************/
+
+/******************************************************************************/
+/*                                   Body                                     */
+/******************************************************************************/
+
+	body {
+		counter-reset: example figure issue;
+
+		/* Layout */
+		max-width: 50em;               /* limit line length to 50em for readability   */
+		margin: 0 auto;                /* center text within page                     */
+		padding: 1.6em 1.5em 2em 50px; /* assume 16px font size for downlevel clients */
+		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag     */
+
+		/* Typography */
+		line-height: 1.5;
+		font-family: sans-serif;
+		widows: 2;
+		orphans: 2;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+		hyphens: auto;
+
+		/* Colors */
+		color: black;
+		background: white top left fixed no-repeat;
+		background-size: 25px auto;
+	}
+
+
+/******************************************************************************/
+/*                         Front Matter & Navigation                          */
+/******************************************************************************/
+
+/** Header ********************************************************************/
+
+	div.head { margin-bottom: 1em }
+	div.head hr { border-style: solid; }
+
+	div.head h1 {
+		font-weight: bold;
+		margin: 0 0 .1em;
+		font-size: 220%;
+	}
+
+	div.head h2 { margin-bottom: 1.5em;}
+
+/** W3C Logo ******************************************************************/
+
+	.head .logo {
+		float: right;
+		margin: 0.4rem 0 0.2rem .4rem;
+	}
+
+	.head img[src*="logos/W3C"] {
+		display: block;
+		border: solid #1a5e9a;
+		border-width: .65rem .7rem .6rem;
+		border-radius: .4rem;
+		background: #1a5e9a;
+		color: white;
+		font-weight: bold;
+	}
+
+	.head a:hover > img[src*="logos/W3C"],
+	.head a:focus > img[src*="logos/W3C"] {
+		opacity: .8;
+	}
+
+	.head a:active > img[src*="logos/W3C"] {
+		background: #c00;
+		border-color: #c00;
+	}
+
+	/* see also additional rules in Link Styling section */
+
+/** Copyright *****************************************************************/
+
+	p.copyright,
+	p.copyright small { font-size: small }
+
+/** Back to Top / ToC Toggle **************************************************/
+
+	@media print {
+		#toc-nav {
+			display: none;
+		}
+	}
+	@media not print {
+		#toc-nav {
+			position: fixed;
+			z-index: 2;
+			bottom: 0; left: 0;
+			margin: 0;
+			min-width: 1.33em;
+			border-top-right-radius: 2rem;
+			box-shadow: 0 0 2px;
+			font-size: 1.5em;
+			color: black;
+		}
+		#toc-nav > a {
+			display: block;
+			white-space: nowrap;
+
+			height: 1.33em;
+			padding: .1em 0.3em;
+			margin: 0;
+
+			background: white;
+			box-shadow: 0 0 2px;
+			border: none;
+			border-top-right-radius: 1.33em;
+			background: white;
+		}
+		#toc-nav > #toc-jump {
+			padding-bottom: 2em;
+			margin-bottom: -1.9em;
+		}
+
+		#toc-nav > a:hover,
+		#toc-nav > a:focus {
+			background: #f8f8f8;
+		}
+		#toc-nav > a:not(:hover):not(:focus) {
+			color: #707070;
+		}
+
+		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
+		#toc-nav > a[href="#toc"]:not(:hover):focus:last-child {
+			padding-bottom: 1.5rem;
+		}
+
+		#toc-nav:not(:hover) > a:not(:focus) > span + span {
+			/* Ideally this uses :focus-within on #toc-nav */
+			display: none;
+		}
+		#toc-nav > a > span + span {
+			padding-right: 0.2em;
+		}
+
+		#toc-toggle-inline {
+			vertical-align: 0.05em;
+			font-size: 80%;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+			border-style: none;
+			background: transparent;
+			position: relative;
+		}
+		#toc-toggle-inline:hover:not(:active),
+		#toc-toggle-inline:focus:not(:active) {
+			text-shadow: 1px 1px silver;
+			top: -1px;
+			left: -1px;
+		}
+
+		#toc-nav :active {
+			color: #C00;
+		}
+	}
+
+/** ToC Sidebar ***************************************************************/
+
+	/* Floating sidebar */
+	@media screen {
+		body.toc-sidebar #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			max-width: 80%;
+			max-width: calc(100% - 2em - 26px);
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body.toc-sidebar #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+		body.toc-sidebar #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	/* Hide main scroller when only the ToC is visible anyway */
+	@media screen and (max-width: 28em) {
+		body.toc-sidebar {
+			overflow: hidden;
+		}
+	}
+
+	/* Sidebar with its own space */
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body:not(.toc-inline) #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+
+		body:not(.toc-inline) {
+			padding-left: 29em;
+		}
+		/* See also Overflow section at the bottom */
+
+		body:not(.toc-inline) #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) {
+			margin: 0 4em;
+		}
+	}
+
+/******************************************************************************/
+/*                                Sectioning                                  */
+/******************************************************************************/
+
+/** Headings ******************************************************************/
+
+	h1, h2, h3, h4, h5, h6, dt {
+		page-break-after: avoid;
+		page-break-inside: avoid;
+		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
+		font-family: inherit;    /* Inherit the font family. */
+		line-height: 1.2;        /* Keep wrapped headings compact */
+		hyphens: manual;         /* Hyphenated headings look weird */
+	}
+
+	h2, h3, h4, h5, h6 {
+		margin-top: 3rem;
+	}
+
+	h1, h2, h3 {
+		color: #005A9C;
+		background: transparent;
+	}
+
+	h1 { font-size: 170%; }
+	h2 { font-size: 140%; }
+	h3 { font-size: 120%; }
+	h4 { font-weight: bold; }
+	h5 { font-style: italic; }
+	h6 { font-variant: small-caps; }
+	dt { font-weight: bold; }
+
+/** Subheadings ***************************************************************/
+
+	h1 + h2,
+	#subtitle {
+		/* #subtitle is a subtitle in an H2 under the H1 */
+		margin-top: 0;
+	}
+	h2 + h3,
+	h3 + h4,
+	h4 + h5,
+	h5 + h6 {
+		margin-top: 1.2em; /* = 1 x line-height */
+	}
+
+/** Section divider ***********************************************************/
+
+	:not(.head) > hr {
+		font-size: 1.5em;
+		text-align: center;
+		margin: 1em auto;
+		height: auto;
+		border: transparent solid 0;
+		background: transparent;
+	}
+	:not(.head) > hr::before {
+		content: "\2727\2003\2003\2727\2003\2003\2727";
+	}
+
+/******************************************************************************/
+/*                            Paragraphs and Lists                            */
+/******************************************************************************/
+
+	p {
+		margin: 1em 0;
+	}
+
+	dd > p:first-child,
+	li > p:first-child {
+		margin-top: 0;
+	}
+
+	ul, ol {
+		margin-left: 0;
+		padding-left: 2em;
+	}
+
+	li {
+		margin: 0.25em 0 0.5em;
+		padding: 0;
+	}
+
+	dl dd {
+		margin: 0 0 .5em 2em;
+	}
+
+	.head dd + dd { /* compact for header */
+		margin-top: -.5em;
+	}
+
+	/* Style for algorithms */
+	ol.algorithm ol:not(.algorithm),
+	.algorithm > ol ol:not(.algorithm) {
+	 border-left: 0.5em solid #DEF;
+	}
+
+	/* Put nice boxes around each algorithm. */
+	[data-algorithm]:not(.heading) {
+	  padding: .5em;
+	  border: thin solid #ddd; border-radius: .5em;
+	  margin: .5em calc(-0.5em - 1px);
+	}
+	[data-algorithm]:not(.heading) > :first-child {
+	  margin-top: 0;
+	}
+	[data-algorithm]:not(.heading) > :last-child {
+	  margin-bottom: 0;
+	}
+
+	/* Style for switch/case <dl>s */
+	dl.switch > dd > ol.only,
+	dl.switch > dd > .only > ol {
+	 margin-left: 0;
+	}
+	dl.switch > dd > ol.algorithm,
+	dl.switch > dd > .algorithm > ol {
+	 margin-left: -2em;
+	}
+	dl.switch {
+	 padding-left: 2em;
+	}
+	dl.switch > dt {
+	 text-indent: -1.5em;
+	 margin-top: 1em;
+	}
+	dl.switch > dt + dt {
+	 margin-top: 0;
+	}
+	dl.switch > dt::before {
+	 content: '\21AA';
+	 padding: 0 0.5em 0 0;
+	 display: inline-block;
+	 width: 1em;
+	 text-align: right;
+	 line-height: 0.5em;
+	}
+
+/** Terminology Markup ********************************************************/
+
+
+/******************************************************************************/
+/*                                 Inline Markup                              */
+/******************************************************************************/
+
+/** Terminology Markup ********************************************************/
+	dfn   { /* Defining instance */
+		font-weight: bolder;
+	}
+	a > i { /* Instance of term */
+		font-style: normal;
+	}
+	dt dfn code, code.idl {
+		font-size: normal;
+	}
+	dfn var {
+		font-style: normal;
+	}
+
+/** Change Marking ************************************************************/
+
+	del { color: red;  text-decoration: line-through; }
+	ins { color: #080; text-decoration: underline;    }
+
+/** Miscellaneous improvements to inline formatting ***************************/
+
+	sup {
+		vertical-align: super;
+		font-size: 80%
+	}
+
+/******************************************************************************/
+/*                                    Code                                    */
+/******************************************************************************/
+
+/** General monospace/pre rules ***********************************************/
+
+	pre, code, samp {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+		font-size: .9em;
+		page-break-inside: avoid;
+		hyphens: none;
+		text-transform: none;
+	}
+	pre code,
+	code code {
+		font-size: 100%;
+	}
+
+	pre {
+		margin-top: 1em;
+		margin-bottom: 1em;
+		overflow: auto;
+	}
+
+/** Inline Code fragments *****************************************************/
+
+  /* Do something nice. */
+
+/******************************************************************************/
+/*                                    Links                                   */
+/******************************************************************************/
+
+/** General Hyperlinks ********************************************************/
+
+	/* We hyperlink a lot, so make it less intrusive */
+	a[href] {
+		color: #034575;
+		text-decoration: none;
+		border-bottom: 1px solid #707070;
+		/* Need a bit of extending for it to look okay */
+		padding: 0 1px 0;
+		margin: 0 -1px 0;
+	}
+	a:visited {
+		border-bottom-color: #BBB;
+	}
+
+	/* Use distinguishing colors when user is interacting with the link */
+	a[href]:focus,
+	a[href]:hover {
+		background: #f8f8f8;
+		background: rgba(75%, 75%, 75%, .25);
+		border-bottom-width: 3px;
+		margin-bottom: -2px;
+	}
+	a[href]:active {
+		color: #C00;
+		border-color: #C00;
+	}
+
+	/* Backout above styling for W3C logo */
+	.head .logo,
+	.head .logo a {
+		border: none;
+		text-decoration: none;
+		background: transparent;
+	}
+
+/******************************************************************************/
+/*                                    Images                                  */
+/******************************************************************************/
+
+	img {
+		border-style: none;
+	}
+
+	/* For autogen numbers, add
+	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
+	*/
+
+	figure, .figure, .sidefigure {
+		page-break-inside: avoid;
+		text-align: center;
+		margin: 2.5em 0;
+	}
+	.figure img,    .sidefigure img,    figure img,
+	.figure object, .sidefigure object, figure object {
+		max-width: 100%;
+		margin: auto;
+	}
+	.figure pre, .sidefigure pre, figure pre {
+		text-align: left;
+		display: table;
+		margin: 1em auto;
+	}
+	.figure table, figure table {
+		margin: auto;
+	}
+	@media screen and (min-width: 20em) {
+		.sidefigure {
+			float: right;
+			width: 50%;
+			margin: 0 0 0.5em 0.5em
+		}
+	}
+	.caption, figcaption, caption {
+		font-style: italic;
+		font-size: 90%;
+	}
+	.caption::before, figcaption::before, figcaption > .marker {
+		font-weight: bold;
+	}
+	.caption, figcaption {
+		counter-increment: figure;
+	}
+
+	/* DL list is indented 2em, but figure inside it is not */
+	dd > .figure, dd > figure { margin-left: -2em }
+
+/******************************************************************************/
+/*                             Colored Boxes                                  */
+/******************************************************************************/
+
+	.issue, .note, .example, .assertion, .advisement, blockquote {
+		padding: .5em;
+		border: .5em;
+		border-left-style: solid;
+		page-break-inside: avoid;
+	}
+	span.issue, span.note {
+		padding: .1em .5em .15em;
+		border-right-style: solid;
+	}
+
+	.issue,
+	.note,
+	.example,
+	.advisement,
+	.assertion,
+	blockquote {
+		margin: 1em auto;
+	}
+	.note  > p:first-child,
+	.issue > p:first-child,
+	blockquote > :first-child {
+		margin-top: 0;
+	}
+	blockquote > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Blockquotes ***************************************************************/
+
+	blockquote {
+		border-color: silver;
+	}
+
+/** Open issue ****************************************************************/
+
+	.issue {
+		border-color: #E05252;
+		background: #FBE9E9;
+		counter-increment: issue;
+		overflow: auto;
+	}
+	.issue::before, .issue > .marker {
+		text-transform: uppercase;
+		color: #AE1E1E;
+		padding-right: 1em;
+		text-transform: uppercase;
+	}
+	/* Add .issue::before { content: "Issue " counter(issue) " "; } for autogen numbers,
+	   or use class="marker" to mark up the issue number in source. */
+
+/** Example *******************************************************************/
+
+	.example {
+		border-color: #E0CB52;
+		background: #FCFAEE;
+		counter-increment: example;
+		overflow: auto;
+		clear: both;
+	}
+	.example::before, .example > .marker {
+		text-transform: uppercase;
+		color: #827017;
+		min-width: 7.5em;
+		display: block;
+	}
+	/* Add .example::before { content: "Example " counter(example) " "; } for autogen numbers,
+	   or use class="marker" to mark up the example number in source. */
+
+/** Non-normative Note ********************************************************/
+
+	.note {
+		border-color: #52E052;
+		background: #E9FBE9;
+		overflow: auto;
+	}
+
+	.note::before, .note > .marker,
+	details.note > summary::before,
+	details.note > summary > .marker {
+		text-transform: uppercase;
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	/* Add .note::before { content: "Note"; } for autogen label,
+	   or use class="marker" to mark up the label in source. */
+
+	details.note > summary {
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	details.note[open] > summary {
+		border-bottom: 1px silver solid;
+	}
+
+/** Assertion Box *************************************************************/
+	/*  for assertions in algorithms */
+
+	.assertion {
+		border-color: #AAA;
+		background: #EEE;
+	}
+
+/** Advisement Box ************************************************************/
+	/*  for attention-grabbing normative statements */
+
+	.advisement {
+		border-color: orange;
+		border-style: none solid;
+		background: #FFEECC;
+	}
+	strong.advisement {
+		display: block;
+		text-align: center;
+	}
+	.advisement > .marker {
+		color: #B35F00;
+	}
+
+/** Spec Obsoletion Notice ****************************************************/
+	/* obnoxious obsoletion notice for older/abandoned specs. */
+
+	details {
+		display: block;
+	}
+	summary {
+		font-weight: bolder;
+	}
+
+	.annoying-warning:not(details),
+	details.annoying-warning:not([open]) > summary,
+	details.annoying-warning[open] {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
+		padding: .75em 1em;
+		border: thick red;
+		border-style: solid;
+		border-radius: 1em;
+	}
+	.annoying-warning :last-child {
+		margin-bottom: 0;
+	}
+
+@media not print {
+	details.annoying-warning[open] {
+		position: fixed;
+		left: 1em;
+		right: 1em;
+		bottom: 1em;
+		z-index: 1000;
+	}
+}
+
+	details.annoying-warning:not([open]) > summary {
+		text-align: center;
+	}
+
+/** Entity Definition Boxes ***************************************************/
+
+	.def {
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+	}
+
+/******************************************************************************/
+/*                                    Tables                                  */
+/******************************************************************************/
+
+	th, td {
+		text-align: left;
+		text-align: start;
+	}
+
+/** Property/Descriptor Definition Tables *************************************/
+
+	table.def {
+		/* inherits .def box styling, see above */
+		width: 100%;
+		border-spacing: 0;
+	}
+
+	table.def td,
+	table.def th {
+		padding: 0.5em;
+		vertical-align: baseline;
+		border-bottom: 1px solid #bbd7e9;
+	}
+
+	table.def > tbody > tr:last-child th,
+	table.def > tbody > tr:last-child td {
+		border-bottom: 0;
+	}
+
+	table.def th {
+		font-style: italic;
+		font-weight: normal;
+		padding-left: 1em;
+		width: 3em;
+	}
+
+	/* For when values are extra-complex and need formatting for readability */
+	table td.pre {
+		white-space: pre-wrap;
+	}
+
+	/* A footnote at the bottom of a def table */
+	table.def           td.footnote {
+		padding-top: 0.6em;
+	}
+	table.def           td.footnote::before {
+		content: " ";
+		display: block;
+		height: 0.6em;
+		width: 4em;
+		border-top: thin solid;
+	}
+
+/** Data tables (and properly marked-up index tables) *************************/
+	/*
+		 <table class="data"> highlights structural relationships in a table
+		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
+
+		 Use class="complex data" for particularly complicated tables --
+		 (This will draw more lines: busier, but clearer.)
+
+		 Use class="long" on table cells with paragraph-like contents
+		 (This will adjust text alignment accordingly.)
+		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
+	*/
+
+	table {
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
+	}
+
+	table.data,
+	table.index {
+		margin: 1em auto;
+		border-collapse: collapse;
+		border: hidden;
+		width: 100%;
+	}
+	table.data caption,
+	table.index caption {
+		max-width: 50em;
+		margin: 0 auto 1em;
+	}
+
+	table.data td,  table.data th,
+	table.index td, table.index th {
+		padding: 0.5em 1em;
+		border-width: 1px;
+		border-color: silver;
+		border-top-style: solid;
+	}
+
+	table.data thead td:empty {
+		padding: 0;
+		border: 0;
+	}
+
+	table.data  thead,
+	table.index thead,
+	table.data  tbody,
+	table.index tbody {
+		border-bottom: 2px solid;
+	}
+
+	table.data colgroup,
+	table.index colgroup {
+		border-left: 2px solid;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		border-right: 2px solid;
+		border-top: 1px solid silver;
+		padding-right: 1em;
+	}
+
+	table.data th[colspan],
+	table.data td[colspan] {
+		text-align: center;
+	}
+
+	table.complex.data th,
+	table.complex.data td {
+		border: 1px solid silver;
+		text-align: center;
+	}
+
+	table.data.longlastcol td:last-child,
+	table.data td.long {
+	 vertical-align: baseline;
+	 text-align: left;
+	}
+
+	table.data img {
+		vertical-align: middle;
+	}
+
+
+/*
+Alternate table alignment rules
+
+	table.data,
+	table.index {
+		text-align: center;
+	}
+
+	table.data  thead th[scope="row"],
+	table.index thead th[scope="row"] {
+		text-align: right;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		text-align: right;
+	}
+
+Possible extra rowspan handling
+
+	table.data  tbody th[rowspan]:not([rowspan='1']),
+	table.index tbody th[rowspan]:not([rowspan='1']),
+	table.data  tbody td[rowspan]:not([rowspan='1']),
+	table.index tbody td[rowspan]:not([rowspan='1']) {
+		border-left: 1px solid silver;
+	}
+
+	table.data  tbody th[rowspan]:first-child,
+	table.index tbody th[rowspan]:first-child,
+	table.data  tbody td[rowspan]:first-child,
+	table.index tbody td[rowspan]:first-child{
+		border-left: 0;
+		border-right: 1px solid silver;
+	}
+*/
+
+/******************************************************************************/
+/*                                  Indices                                   */
+/******************************************************************************/
+
+
+/** Table of Contents *********************************************************/
+
+	.toc a {
+		/* More spacing; use padding to make it part of the click target. */
+		padding-top: 0.1rem;
+		/* Larger, more consistently-sized click target */
+		display: block;
+		/* Reverse color scheme */
+		color: black;
+		border-color: #3980B5;
+		border-bottom-width: 3px !important;
+		margin-bottom: 0px !important;
+	}
+	.toc a:visited {
+		border-color: #054572;
+	}
+	.toc a:not(:focus):not(:hover) {
+		/* Allow colors to cascade through from link styling */
+		border-bottom-color: transparent;
+	}
+
+	.toc, .toc ol, .toc ul, .toc li {
+		list-style: none; /* Numbers must be inlined into source */
+		/* because generated content isn't search/selectable and markers can't do multilevel yet */
+		margin:  0;
+		padding: 0;
+		line-height: 1.1rem; /* consistent spacing */
+	}
+
+	/* ToC not indented until third level, but font style & margins show hierarchy */
+	.toc > li             { font-weight: bold;   }
+	.toc > li li          { font-weight: normal; }
+	.toc > li li li       { font-size:   95%;    }
+	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li li { font-size:   85%;    }
+
+	.toc > li             { margin: 1.5rem 0;    }
+	.toc > li li          { margin: 0.3rem 0;    }
+	.toc > li li li       { margin-left: 2rem;   }
+
+	/* Section numbers in a column of their own */
+	.toc .secno {
+		float: left;
+		width: 4rem;
+		white-space: nowrap;
+	}
+	.toc > li li li li .secno {
+		font-size: 85%;
+	}
+	.toc > li li li li li .secno {
+		font-size: 100%;
+	}
+
+	:not(li) > .toc              { margin-left:  5rem; }
+	.toc .secno                  { margin-left: -5rem; }
+	.toc > li li li .secno       { margin-left: -7rem; }
+	.toc > li li li li .secno    { margin-left: -9rem; }
+	.toc > li li li li li .secno { margin-left: -11rem; }
+
+	/* Tighten up indentation in narrow ToCs */
+	@media (max-width: 30em) {
+		:not(li) > .toc              { margin-left:  4rem; }
+		.toc .secno                  { margin-left: -4rem; }
+		.toc > li li li              { margin-left:  1rem; }
+		.toc > li li li .secno       { margin-left: -5rem; }
+		.toc > li li li li .secno    { margin-left: -6rem; }
+		.toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
+		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
+		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
+		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
+		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
+		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
+	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
+	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
+	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
+	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
+	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+
+	.toc li {
+		clear: both;
+	}
+
+
+/** Index *********************************************************************/
+
+	/* Index Lists: Layout */
+	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
+	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
+	ul.index li li { margin-left: 1em }
+	ul.index dl    { margin-top: 0; }
+	ul.index dt    { margin: .2em 0 .2em 20px;}
+	ul.index dd    { margin: .2em 0 .2em 40px;}
+	/* Index Lists: Typography */
+	ul.index ul,
+	ul.index dl { font-size: smaller; }
+	@media not print {
+		ul.index li span {
+			white-space: nowrap;
+			color: transparent; }
+		ul.index li a:hover + span,
+		ul.index li a:focus + span {
+			color: #707070;
+		}
+	}
+
+/** Index Tables *****************************************************/
+	/* See also the data table styling section, which this effectively subclasses */
+
+	table.index {
+		font-size: small;
+		border-collapse: collapse;
+		border-spacing: 0;
+		text-align: left;
+		margin: 1em 0;
+	}
+
+	table.index td,
+	table.index th {
+		padding: 0.4em;
+	}
+
+	table.index tr:hover td:not([rowspan]),
+	table.index tr:hover th:not([rowspan]) {
+		background: #f7f8f9;
+	}
+
+	/* The link in the first column in the property table (formerly a TD) */
+	table.index th:first-child a {
+		font-weight: bold;
+	}
+
+/******************************************************************************/
+/*                                    Print                                   */
+/******************************************************************************/
+
+	@media print {
+		/* Pages have their own margins. */
+		html {
+			margin: 0;
+		}
+		/* Serif for print. */
+		body {
+			font-family: serif;
+		}
+	}
+	@page {
+		margin: 1.5cm 1.1cm;
+	}
+
+/******************************************************************************/
+/*                                    Legacy                                  */
+/******************************************************************************/
+
+	/* This rule is inherited from past style sheets. No idea what it's for. */
+	.hide { display: none }
+
+
+
+/******************************************************************************/
+/*                             Overflow Control                               */
+/******************************************************************************/
+
+	.figure .caption, .sidefigure .caption, figcaption {
+		/* in case figure is overlarge, limit caption to 50em */
+		max-width: 50rem;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.overlarge > table {
+		/* limit preferred width of table */
+		max-width: 50em;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	@media (min-width: 55em) {
+		.overlarge {
+			margin-left: calc(13px + 26.5rem - 50vw);
+			margin-right: calc(13px + 26.5rem - 50vw);
+			max-width: none;
+		}
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) .overlarge {
+			/* 30.5em body padding 50em content area */
+			margin-left: calc(40em - 50vw) !important;
+			margin-right: calc(40em - 50vw) !important;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) .overlarge {
+			/* 4em html margin 30.5em body padding 50em content area */
+			margin-left: 0 !important;
+			margin-right: calc(84.5em - 100vw) !important;
+		}
+	}
+
+	@media not print {
+		.overlarge {
+			overflow-x: auto;
+			/* See Lea Verou's explanation background-attachment:
+			 * http://lea.verou.me/2012/04/background-attachment-local/
+			 *
+			background: top left  / 4em 100% linear-gradient(to right,  #ffffff, rgba(255, 255, 255, 0)) local,
+			            top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
+			            top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            white;
+			background-repeat: no-repeat;
+			*/
+		}
+	}
+</style>
+  <meta content="Bikeshed version e5f1ea6cfe87cd694cb9d91f26be2d18374ebb1f" name="generator">
+<style>/* style-md-lists */
+
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-selflinks */
+
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
+
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-counters */
+
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
+
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
+
+            figcaption {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure) " ";
+            }</style>
+<style>/* style-autolinks */
+
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
+
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
+
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
+
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
+<style>/* style-dfn-panel */
+
+        .dfn-panel {
+            position: absolute;
+            z-index: 35;
+            height: auto;
+            width: -webkit-fit-content;
+            width: fit-content;
+            max-width: 300px;
+            max-height: 500px;
+            overflow: auto;
+            padding: 0.5em 0.75em;
+            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+            background: #DDDDDD;
+            color: black;
+            border: outset 0.2em;
+        }
+        .dfn-panel:not(.on) { display: none; }
+        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+        .dfn-panel > b { display: block; }
+        .dfn-panel a { color: black; }
+        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+        .dfn-panel > b + b { margin-top: 0.25em; }
+        .dfn-panel ul { padding: 0; }
+        .dfn-panel li { list-style: inside; }
+        .dfn-panel.activated {
+            display: inline-block;
+            position: fixed;
+            left: .5em;
+            bottom: 2em;
+            margin: 0 auto;
+            max-width: calc(100vw - 1.5em - .4em - .5em);
+            max-height: 30vh;
+        }
+
+        .dfn-paneled { cursor: pointer; }
+        </style>
+<style>/* style-railroad */
+svg.railroad-diagram{background-color:hsl(30,20%,95%);}svg.railroad-diagram path{stroke-width:3;stroke:black;fill:rgba(0,0,0,0);}svg.railroad-diagram text{font:bold 14px monospace;text-anchor:middle;}svg.railroad-diagram text.label{text-anchor:start;}svg.railroad-diagram text.comment{font:italic 12px monospace;}svg.railroad-diagram rect{stroke-width:3;stroke:black;fill:hsl(120,100%,90%);}</style>
+<style>/* style-syntax-highlighting */
+pre.idl.highlight { color: #708090; }
+        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+        code.highlight { padding: .1em; border-radius: .3em; }
+        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+        .highlight .c { color: #708090 } /* Comment */
+        .highlight .k { color: #990055 } /* Keyword */
+        .highlight .l { color: #000000 } /* Literal */
+        .highlight .n { color: #0077aa } /* Name */
+        .highlight .o { color: #999999 } /* Operator */
+        .highlight .p { color: #999999 } /* Punctuation */
+        .highlight .cm { color: #708090 } /* Comment.Multiline */
+        .highlight .cp { color: #708090 } /* Comment.Preproc */
+        .highlight .c1 { color: #708090 } /* Comment.Single */
+        .highlight .cs { color: #708090 } /* Comment.Special */
+        .highlight .kc { color: #990055 } /* Keyword.Constant */
+        .highlight .kd { color: #990055 } /* Keyword.Declaration */
+        .highlight .kn { color: #990055 } /* Keyword.Namespace */
+        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
+        .highlight .kr { color: #990055 } /* Keyword.Reserved */
+        .highlight .kt { color: #990055 } /* Keyword.Type */
+        .highlight .ld { color: #000000 } /* Literal.Date */
+        .highlight .m { color: #000000 } /* Literal.Number */
+        .highlight .s { color: #a67f59 } /* Literal.String */
+        .highlight .na { color: #0077aa } /* Name.Attribute */
+        .highlight .nc { color: #0077aa } /* Name.Class */
+        .highlight .no { color: #0077aa } /* Name.Constant */
+        .highlight .nd { color: #0077aa } /* Name.Decorator */
+        .highlight .ni { color: #0077aa } /* Name.Entity */
+        .highlight .ne { color: #0077aa } /* Name.Exception */
+        .highlight .nf { color: #0077aa } /* Name.Function */
+        .highlight .nl { color: #0077aa } /* Name.Label */
+        .highlight .nn { color: #0077aa } /* Name.Namespace */
+        .highlight .py { color: #0077aa } /* Name.Property */
+        .highlight .nt { color: #669900 } /* Name.Tag */
+        .highlight .nv { color: #222222 } /* Name.Variable */
+        .highlight .ow { color: #999999 } /* Operator.Word */
+        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
+        .highlight .mf { color: #000000 } /* Literal.Number.Float */
+        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
+        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
+        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
+        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
+        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
+        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
+        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
+        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
+        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+        </style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">Feature Policy</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-02-22">22 February 2017</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="https://wicg.github.io/feature-policy/">https://wicg.github.io/feature-policy/</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/wicg/feature-policy/issues/">GitHub</a>
+     <dd><a href="#issues-index">Inline In Spec</a>
+     <dt class="editor">Editors:
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:igrigorik@google.com">Ilya Grigorik</a> (<span class="p-org org">Google</span>)
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:mkwst@google.com">Mike West</a> (<span class="p-org org">Google</span>)
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2015 the Contributors to the Feature Policy Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>This specification defines a mechanism that allows developers to selectively enable and disable use of various browser features and APIs.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This specification was published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+
+  Learn more about <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#examples"><span class="secno">2</span> <span class="content">Examples</span></a>
+    <li><a href="#other-and-related-mechanisms"><span class="secno">3</span> <span class="content">Other and related mechanisms</span></a>
+    <li>
+     <a href="#framwork"><span class="secno">4</span> <span class="content">Framework</span></a>
+     <ol class="toc">
+      <li><a href="#features"><span class="secno">4.1</span> <span class="content">Features</span></a>
+      <li><a href="#policies"><span class="secno">4.2</span> <span class="content">Policies</span></a>
+      <li><a href="#inherited-policies"><span class="secno">4.3</span> <span class="content">Inherited policies</span></a>
+      <li><a href="#declared-policies"><span class="secno">4.4</span> <span class="content">Declared policies</span></a>
+      <li><a href="#header-policies"><span class="secno">4.5</span> <span class="content">Header policies</span></a>
+      <li><a href="#container-policies"><span class="secno">4.6</span> <span class="content">Container policies</span></a>
+      <li><a href="#policy-directives"><span class="secno">4.7</span> <span class="content">Policy directives</span></a>
+      <li><a href="#allowlists"><span class="secno">4.8</span> <span class="content">Allowlists</span></a>
+      <li><a href="#default-allowlists"><span class="secno">4.9</span> <span class="content">Default Allowlists</span></a>
+     </ol>
+    <li>
+     <a href="#serialization"><span class="secno">5</span> <span class="content">Feature Policy Serialization</span></a>
+     <ol class="toc">
+      <li><a href="#json-serialization"><span class="secno">5.1</span> <span class="content">JSON serialization</span></a>
+     </ol>
+    <li>
+     <a href="#delivery"><span class="secno">6</span> <span class="content">Delivery</span></a>
+     <ol class="toc">
+      <li><a href="#feature-policy-http-header-field"><span class="secno">6.1</span> <span class="content">Feature-Policy HTTP Header
+    Field</span></a>
+      <li><a href="#feature-policy-meta-element"><span class="secno">6.2</span> <span class="content">The <code>meta</code> element</span></a>
+      <li><a href="#iframe-allow-attribute"><span class="secno">6.3</span> <span class="content">The <code>allow</code> attribute of the <code>iframe</code> element</span></a>
+      <li>
+       <a href="#legacy-attributes"><span class="secno">6.4</span> <span class="content">Additional attributes to support legacy
+    features</span></a>
+       <ol class="toc">
+        <li><a href="#iframe-allowfullscreen-attribute"><span class="secno">6.4.1</span> <span class="content">allowfullscreen</span></a>
+        <li><a href="#iframe-allowpaymentrequest-attribute"><span class="secno">6.4.2</span> <span class="content">allowpaymentrequest</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#integrations"><span class="secno">7</span> <span class="content">Integrations</span></a>
+     <ol class="toc">
+      <li>
+       <a href="#integration-with-html"><span class="secno">7.1</span> <span class="content">Integration with HTML</span></a>
+       <ol class="toc">
+        <li><a href="#process-meta-policy"><span class="secno">7.1.1</span> <span class="content">Process meta policy</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#algorithms"><span class="secno">8</span> <span class="content">Algorithms</span></a>
+     <ol class="toc">
+      <li><a href="#process-response-policy"><span class="secno">8.1</span> <span class="content">Process response policy</span></a>
+      <li><a href="#parse-header"><span class="secno">8.2</span> <span class="content">Parse header from <var>value</var> and <var>origin</var></span></a>
+      <li><a href="#parse-policy-directive"><span class="secno">8.3</span> <span class="content">Parse policy directive from <var>value</var> and <var>origin</var></span></a>
+      <li><a href="#merge-directive-with-declared-policy"><span class="secno">8.4</span> <span class="content">Merge directive with declared
+    policy</span></a>
+      <li><a href="#process-feature-policy-attributes"><span class="secno">8.5</span> <span class="content">Process feature policy
+    attributes</span></a>
+      <li><a href="#parse-allow-attribute"><span class="secno">8.6</span> <span class="content">Parse allow attribute</span></a>
+      <li><a href="#initialize-for-global"><span class="secno">8.7</span> <span class="content">Initialize <var>global</var>’s Feature
+    Policy from <var>response</var></span></a>
+      <li><a href="#define-inherited-policy"><span class="secno">8.8</span> <span class="content">Define an inherited policy for <var>feature</var></span></a>
+      <li><a href="#is-feature-enabled"><span class="secno">8.9</span> <span class="content">Is <var>feature</var> enabled in <var>global</var> for <var>origin</var>?</span></a>
+     </ol>
+    <li><a href="#iana-considerations"><span class="secno">9</span> <span class="content">IANA Considerations</span></a>
+    <li><a href="#privacy-and-security"><span class="secno">10</span> <span class="content">Privacy and Security</span></a>
+    <li>
+     <a href="#defined-features"><span class="secno"></span> <span class="content">Appendix A: Features</span></a>
+     <ol class="toc">
+      <li>
+       <a href="#feature-definitions"><span class="secno"></span> <span class="content">Feature Definitions</span></a>
+       <ol class="toc">
+        <li><a href="#camera-feature"><span class="secno"></span> <span class="content">camera</span></a>
+        <li><a href="#eme-feature"><span class="secno"></span> <span class="content">eme</span></a>
+        <li><a href="#fullscreen-feature"><span class="secno"></span> <span class="content">fullscreen</span></a>
+        <li><a href="#geolocation-feature"><span class="secno"></span> <span class="content">geolocation</span></a>
+        <li><a href="#microphone-feature"><span class="secno"></span> <span class="content">microphone</span></a>
+        <li><a href="#midi-feature"><span class="secno"></span> <span class="content">midi</span></a>
+        <li><a href="#payment-feature"><span class="secno"></span> <span class="content">payment</span></a>
+        <li><a href="#speaker-feature"><span class="secno"></span> <span class="content">speaker</span></a>
+        <li><a href="#vibrate-feature"><span class="secno"></span> <span class="content">vibrate</span></a>
+       </ol>
+     </ol>
+    <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
+   </ol>
+  </nav>
+  <main>
+   <section>
+    <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
     <p>The web-platform provides an ever-expanding set of features and APIs,
-    offering richer functionality, better developer ergonomics, and improved
-    performance. However, a missing piece is the ability for the developer to
-    selectively enable, disable, or modify the behavior of some of these
-    browser features and APIs within their application:</p>
+  offering richer functionality, better developer ergonomics, and improved
+  performance. However, a missing piece is the ability for the developer to
+  selectively enable, disable, or modify the behavior of some of these browser
+  features and APIs within their application:</p>
     <ol>
-      <li>The developer may want to selectively _disable_ access to certain
-      browser features and APIs to "lock down" their application, as a security
-      or performance precaution, to prevent own and third-party content
-      executing within their application from introducing unwanted or
-      unexpected behaviors within their application.</li>
-      <li>The developer may want to selectively _enable_ access to certain
-      browser features and APIs which may be disabled by default - e.g. some
-      features may be disabled by default in embedded context unless explicitly
-      enabled; some features may be subject to other policy requirements.</li>
-      <li>The developer may want to use the policy to assert a promise to a
-      client or an embedder about the use—or lack of thereof—of certain
-      features and APIs. For example, to enable certain types of "fast path"
-      optimizations in the browser, or to assert a promise about conformance
-      with some requirements set by other embedders - e.g. various social
-      networks, search engines, and so on.</li>
+     <li>The developer may want to selectively <em>disable</em> access to certain
+    browser features and APIs to "lock down" their application, as a security
+    or performance precaution, to prevent own and third-party content executing
+    within their application from introducing unwanted or unexpected behaviors
+    within their application.
+     <li>The developer may want to selectively <em>enable</em> access to certain
+    browser features and APIs which may be disabled by default - e.g. some
+    features may be disabled by default in embedded context unless explicitly
+    enabled; some features may be subject to other policy requirements.
+     <li>The developer may want to use the policy to assert a promise to a
+    client or an embedder about the use—or lack of thereof—of certain features
+    and APIs. For example, to enable certain types of "fast path" optimizations
+    in the browser, or to assert a promise about conformance with some
+    requirements set by other embedders - e.g. various social networks, search
+    engines, and so on.
     </ol>
     <p>This specification defines a feature policy mechanism that addresses the
-    above use cases.</p>
+  above use cases.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="2" id="examples"><span class="secno">2. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
+    <div class="example" id="example-52d29d08">
+     <a class="self-link" href="#example-52d29d08"></a> 
+     <p>SecureCorp Inc. wants to disable use of Vibration and Geolocation APIs
+    within their application. It can do so by delivering the following HTTP
+    response header to define a feature policy:</p>
+<pre><a href="#feature-policy-header" id="ref-for-feature-policy-header-1">Feature-Policy</a>: {"<a data-link-type="dfn" href="#vibrate" id="ref-for-vibrate-1">vibrate</a>": [], "<a data-link-type="dfn" href="#geolocation" id="ref-for-geolocation-1">geolocation</a>": []}</pre>
+     <p>By specifying an empty list of origins, the specified features will be
+    disabled for all browsing contexts, regardless of their origin.</p>
+    </div>
+    <div class="example" id="example-dbaf5c3d">
+     <a class="self-link" href="#example-dbaf5c3d"></a> 
+     <p>SecureCorp Inc. wants to disable use of Geolocation API within all
+    browsing contexts except for its own origin and those whose origin is
+    "<code>https://example.com</code>". It can do so by delivering the
+    following HTTP response header to define a feature policy:</p>
+<pre><a href="#feature-policy-header" id="ref-for-feature-policy-header-2">Feature-Policy</a>: {"<a data-link-type="dfn" href="#geolocation" id="ref-for-geolocation-2">geolocation</a>": ["self", "https://example.com"]}</pre>
+     <p>The <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-1">allowlist</a> is a list of one or more origins, which can include
+    the application’s origin, optionally with the keyword "<code>self</code>",
+    and any third-party origin.</p>
+    </div>
+    <div class="example" id="example-1a39f611">
+     <a class="self-link" href="#example-1a39f611"></a> 
+     <p>SecureCorp Inc. is hosting an application on
+    "<code>https://example.com</code>" and wants to disable camera and
+    microphone input on its own origin but enable it for a whitelisted embedee
+    ("<code>https://other.com</code>"). It can do so by delivering the
+    following HTTP response header to define a feature policy:</p>
+<pre><a href="#feature-policy-header" id="ref-for-feature-policy-header-3">Feature-Policy</a>: {"<a data-link-type="dfn" href="#camera" id="ref-for-camera-1">camera</a>": ["https://other.com"], "<a data-link-type="dfn" href="#microphone" id="ref-for-microphone-1">microphone</a>": ["https://other.com"]}</pre>
+     <p>Some features are disabled by default in embedded contexts. The enable
+    policy allows the application to selectively enable such features for
+    whitelisted origins.</p>
+    </div>
+    <div class="example" id="example-98245816">
+     <a class="self-link" href="#example-98245816"></a> 
+     <p>FastCorp Inc. wants to disable geolocation for all cross-origin child
+    frames, except for a specific iframe. It can do so by delivering the
+    following HTTP response header to define a feature policy:</p>
+<pre><a href="#feature-policy-header" id="ref-for-feature-policy-header-4">Feature-Policy</a>: {"<a data-link-type="dfn" href="#geolocation" id="ref-for-geolocation-3">geolocation</a>": ["self"]}</pre>
+     <p>and including an "<code>allow</code>" attribute on the iframe
+    element:</p>
+<pre>&lt;iframe src="https://other.com/map" <a href="#iframe-allow-attribute">allow</a>="<a data-link-type="dfn" href="#geolocation" id="ref-for-geolocation-4">geolocation</a>">&lt;/iframe></pre>
+     <p>Iframe attributes can selectively enable features in certain frames, and
+    not in others, even if those contain documents from the same origin.</p>
+    </div>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="3" id="other-and-related-mechanisms"><span class="secno">3. </span><span class="content">Other and related mechanisms</span><a class="self-link" href="#other-and-related-mechanisms"></a></h2>
+    <p><a data-link-type="biblio" href="#biblio-html5">[HTML5]</a> defines a <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-sandbox">sandbox</a></code> attribute for <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> elements
+  that allows developers to reduce the risk of including potentially untrusted
+  content by imposing restrictions on content’s abilities - e.g. prevent it
+  from submitting forms, running scripts and plugins, and more. The <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#sandbox">sandbox</a> directive defined by <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a> extends this capability to any
+  resource, framed or not, to ask for the same set of restrictions - e.g. via an
+  HTTP response header (<code>Content-Security-Policy: sandbox</code>). These
+  mechanisms enable the developer to:</p>
+    <ul>
+     <li>Set and customize a sandbox policy on any resource via CSP.
+     <li>Set and customize individual sandbox policies on each <code>iframe</code> element within their application.
+    </ul>
+    <p>However, there are several limitations to the above mechanism: the
+  developer cannot automatically apply a policy across all contexts, which
+  makes it hard or impossible to enforce consistently in some cases (e.g. due
+  to third-party content injecting frames, which the developer does not
+  control); there is no mechanism to selectively enable features that may be
+  off by default; the sandbox mechanism uses a whietlist approach which is
+  impossible to extend without compatibility risk.</p>
+    <p>Feature Policy is intended to be used in combination with the sandbox
+  mechanism (i.e. it does not duplicate feature controls already covered by
+  sandbox), and provides an extensible mechanism that addresses the above
+  limitations.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="4" id="framwork"><span class="secno">4. </span><span class="content">Framework</span><a class="self-link" href="#framwork"></a></h2>
     <section>
-      <h2>Examples</h2>
-      <div class="example">
-        <p>SecureCorp Inc. wants to disable use of WebRTC and Geolocation APIs
-        within their application. It can do so by delivering the following HTTP
-        response header to define a feature policy:</p>
-        <pre><a>Feature-Policy</a>: {"<a data-lt=
-        "disable member">disable</a>":["<a>webrtc</a>","<a>geolocation</a>"]}</pre>
-        <p>Unless specified otherwise, the default <a>target</a> is "`\*`",
-        which means that the specified features will be disabled for all
-        browsing contexts regardless of their origin.</p>
-      </div>
-      <div class="example">
-        <p>SecureCorp Inc. wants to disable use of Geolocation API within all
-        browsing contexts whose origin is "`https://example.com`". It can do so
-        by delivering the following HTTP response header to define a feature
-        policy:</p>
-        <pre><a>Feature-Policy</a>: {"<a data-lt=
-        "disable member">disable</a>":["<a>geolocation</a>"], "<a data-lt=
-        "target member">target</a>":["https://example.com"]}</pre>
-        <p>The <a>target</a> is a list of one or more origins, which can
-        include the applications origin and any third-party origin.</p>
-      </div>
-      <div class="example">
-        <p>SecureCorp Inc. is hosting an application on "`https://example.com`"
-        and wants to disable WebRTC on its origin but enable it for a
-        whitelisted embedee ("`https://other.com`"). It can do so by delivering
-        the following HTTP response header to define a feature policy:</p>
-        <pre><a>Feature-Policy</a>: {"<a data-lt=
-        "disable member">disable</a>":["<a>webrtc</a>"], "<a data-lt=
-        "target member">target</a>":["https://example.com"]},
-        {"<a data-lt=
-"enable member">enable</a>":["<a>webrtc</a>"], "<a data-lt="target member">target</a>":["https://other.com"]}</pre>
-        <p>Some features are disabled by default in embedded contexts. The
-        enable policy allows the application to selectively enable such
-        features for whitelisted origins.</p>
-      </div>
-      <div class="example">
-        <p>FastCorp Inc. wants to disable use of synchronous `script` elements,
-        synchronous `XMLHttpRequest`'s and use of `document.write` within their
-        application. It can do so by delivering the following HTTP response
-        header to define a feature policy:</p>
-        <pre><a>Feature-Policy</a>: {"<a data-lt=
-        "disable member">disable</a>":["<a>sync-xhr</a>","<a>sync-script</a>","<a>docwrite</a>"]}</pre>
-      </div>
+     <h3 class="heading settled" data-level="4.1" id="features"><span class="secno">4.1. </span><span class="content">Features</span><a class="self-link" href="#features"></a></h3>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature">feature</dfn> controlled by this framework is an API or behaviour
+    which can be enabled or disabled in a document or web worker by referring to
+    it in a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-1">feature policy</a>. </p>
+     <p><a data-link-type="dfn" href="#feature" id="ref-for-feature-1">Features</a> have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-name">feature name</dfn> keyword, which is a token
+    used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-1">policy directives</a>, and a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-1">default allowlist</a>, which
+    defines whether the <a data-link-type="dfn" href="#feature" id="ref-for-feature-2">feature</a> is available to top-level documents, and
+    how access to that feature is inherited by cross-origin frames.</p>
+     <p>A user agent has a set of <dfn data-dfn-type="dfn" data-noexport="" id="supported-features">supported features<a class="self-link" href="#supported-features"></a></dfn>, which is the set
+    of <a data-link-type="dfn" href="#feature" id="ref-for-feature-3">features</a> which it allows to be controlled through policies. User
+    agents are not required to support every <a data-link-type="dfn" href="#feature" id="ref-for-feature-4">feature</a>.</p>
+     <p><a data-link-type="dfn" href="#feature" id="ref-for-feature-5">Features</a> themselves are not themselves part of this framework. A
+    non-normative list of currently-defined features is included as an appendix
+    to this specification. </p>
     </section>
     <section>
-      <h2>Other and related mechanisms</h2>
-      <p>[[HTML5]] defines a [sandbox attribute] for `iframe` elements that
-      allows developers to reduce the risk of including potentially untrusted
-      content by imposing restrictions on content's abilities - e.g. prevent it
-      from submitting forms, running scripts and plugins, and more. The
-      [sandbox directive] defined by [[CSP2]] extends this capability to any
-      resource, framed or not, to ask for the same set of restrictions - e.g.
-      via an HTTP response header (`Content-Security-Policy: sandbox`). These
-      mechanisms enable the developer to:</p>
-      <ul>
-        <li>Set and customize a sandbox policy on any resource via CSP.</li>
-        <li>Set and customize individual sandbox policies on each `iframe`
-        element within their application.</li>
-      </ul>
-      <p>However, there are several limitations to the above mechanism: the
-      developer cannot automatically apply a policy across all contexts, which
-      makes it hard or impossible to enforce consistently in some cases (e.g.
-      due to third-party content injecting frames, which the developer does not
-      control); there is no mechanism to selectively enable features that may
-      be off by default; the sandbox mechanism uses a whitelist approach which
-      is impossible to extend without compatibility risk.</p>
-      <p>Feature Policy is intended to be used in combination with the sandbox
-      mechanism (i.e. it does not duplicate feature controls already covered by
-      sandbox), and provides an extensible mechanism that addresses the above
-      limitations.</p>
-    </section>
-  </section>
-  <section>
-    <h2>Framework</h2>
-    <section>
-      <h2>Policies</h2>
-      <p>A <dfn>feature policy</dfn> may be applied to a [Window] or
-      [WorkerGlobalScope] and consists of:</p>
-      <ul>
-        <li>A set of <a data-lt="directive">directives</a>.
-        </li>
-      </ul>
+     <h3 class="heading settled" data-level="4.2" id="policies"><span class="secno">4.2. </span><span class="content">Policies</span><a class="self-link" href="#policies"></a></h3>
+     <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-policy">feature policy</dfn>,
+    which consists of:</p>
+     <ul>
+      <li>A set of <a data-link-type="dfn" href="#inherited-policy-set" id="ref-for-inherited-policy-set-1">inherited policies</a>. 
+      <li>A <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-1">declared policy</a>. 
+     </ul>
     </section>
     <section>
-      <h2>Directives</h2>
-      <p>Each <dfn>directive</dfn> is a tuple consisting of:</p>
-      <ul>
-        <li>A <dfn>target</dfn> set by the <var>target member</var>.</li>
-        <li>A <dfn>disable</dfn> list set by the <var>disable
-        member</var>.</li>
-        <li>A <dfn>enable</dfn> list set by the <var>enable member</var>.</li>
-      </ul>
-      <p>The following sections define the set of known members in each JSON
-      object describing the policy. Future versions of this document may define
-      additional such members and user agents MUST ignore unknown members when
-      parsing the object.</p>
-      <section>
-        <h2>The <var>target member</var></h2>
-        <p>The OPTIONAL <dfn>target member</dfn> defines the scope in which the
-        directive is enforced. The member's name is "`target`" and the
-        recognized values are either an array of serialized origins which may
-        contain the "`self`" keyword that refers to current global's origin, or
-        the string "`\*`". If an unknown value is specified, or if no member
-        named "`target`" is present in the object, the <a>directive</a>'s
-        <a>target</a> will be set to "`\*`".</p>
-      </section>
-      <section>
-        <h2>The <var>disable member</var></h2>
-        <p>The OPTIONAL <dfn>disable member</dfn> defines the <a>disable
-        policy</a> for the directive. The member's name is "`disable`" and the
-        value is a list of ASCII strings.</p>
-      </section>
-      <section>
-        <h2>The <var>enable member</var></h2>
-        <p>The OPTIONAL <dfn>enable member</dfn> defines the <a>enable
-        policy</a> for the directive. The member's name is "`enable`" and the
-        value is a list of ASCII strings. [response]</p>
-      </section>
+     <h3 class="heading settled" data-level="4.3" id="inherited-policies"><span class="secno">4.3. </span><span class="content">Inherited policies</span><a class="self-link" href="#inherited-policies"></a></h3>
+     <p>Each document in a frame tree inherits a set of policies from its parent
+    frame, or in the case of the top-level document, from the defined defaults
+    for each feature. This inherited policy set determines the initial state
+    (enabled or disabled) of each feature, and whether it can be controlled by
+    a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-2">declared policy</a> in the document.</p>
+     <p>In a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>, or in a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>, the inherited feature set is based on defined
+    defaults for each feature.</p>
+     <p>In a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>, the inherited feature
+    set is based on the parent document’s feature policy, as well as any <a href="#iframe-allow-attribute">allow attributes</a> defined on the
+    browsing context container.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="inherited policy|inherited policies" data-noexport="" id="inherited-policy">inherited
+    policy</dfn> for a <a data-link-type="dfn" href="#feature" id="ref-for-feature-6">feature</a> is a boolean associated with that feature
+    in a Document or WorkerGlobalScope. It can take the value Enabled or
+    Disabled.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inherited-policy-set">inherited policy set</dfn> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is the set of <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-1">inherited policies</a> for each <a data-link-type="dfn" href="#feature" id="ref-for-feature-7">feature</a> available in that scope.</p>
     </section>
     <section>
-      <h2>Delivery</h2>
-      <section>
-        <h2>`Feature-Policy` HTTP Header Field</h2>
-        <p>The <dfn>Feature-Policy</dfn> HTTP header field can be used both in
-        the [response] (server to client) and a [request] (client to server) to
-        communicate the <a>feature policy</a>. In the former case, the server
-        is communicating the desired policy that should be enforced by the
-        client, and in the latter, the client is communicating the policy that
-        it will enforce.</p>
-        <p>The header's value is represented by the following ABNF
-        [[!RFC5234]]:</p>
-        <pre class="abnf">
-          Disable = 1#json-field-value
-                    ; See Section 2 of [[HTTP-JFV]], and Section 2 of [[RFC7159]]
-        </pre>
-        <p>When the user agent receives a `Feature-Policy` header field, it
-        MUST <a href="#process-response-policy">process</a> and <a>enforce</a>
-        the serialized policy as described in <a href=
-        "#integration-with-html"></a>. When the user agent [performs a
-        fetch][fetching algorithm], it MUST advertise the active <a>feature
-        policy</a> as described in <a href="#integration-with-fetch"></a>.</p>
-        <h2>Process response policy</h2>
-        <p>Given a [response] (<var>response</var>) and [global object]
-        (<var>global</var>), this algorithm returns a <a>feature
-        policy</a>.</p>
-        <ol>
-          <li>Abort these steps if the <var>response</var>’s [header list] does
-          not contain a [header] whose [name] is "`Feature-Policy`".</li>
-          <li>Let <var>header</var> be the [value] of the [header] in
-          <var>response</var>’s [header list] whose name is
-          "`Feature-Policy`".</li>
-          <li>Let <var>feature policy</var> be the result of executing
-            <a href="#parse-policy-from-value-and-global"></a> on
-            <var>header</var> and <var>global</var>.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2>The `meta` element</h2>
-        <p>A [Document] may deliver a policy via one or more HTML [meta]
-        elements whose [http-equiv] attributes are an [ASCII case-insensitive]
-        match for the string "`Feature-Policy`". For example:</p>
-        <pre class="example nolinks">
-&lt;meta http-equiv="Feature-Policy"
-  content='{"disable": ["webrtc"]},
-           {"enable":["geolocation"],"target":["https://example.com"}'&gt;
-        </pre>
-        <p>The `meta` policy is processed as defined in <a href=
-        "#process-meta-policy"></a> and modifications to the
-        [content][meta-content] attribute of a `meta` element after the element
-        has been parsed MUST be ignored.</p>
-        <p class="issue">TODO: talk about effect of multiple policies</p>
-        <section>
-          <h2>Process meta policy</h2>
-          <p class="note">This section extends HTML's `meta` [pragma
-          directives].</p><strong>Feature policy state
-          (http-equiv="feature-policy")</strong>
-          <ol>
-            <li>If the `meta` element is not a child of a `head` element, abort
-            these steps.</li>
-            <li>If the `meta` element is preceded by `link`, `script` or
-            `style` elements, abort these steps.</li>
-            <li>If the `meta` element has no [content][meta-content] attribute,
-            or if that attribute's value is the empty string, then abort these
-            steps.</li>
-            <li>Let <var>policy</var> be the result of executing <a href=
-            "#parse-policy-from-value-and-global"></a> on the `meta` element's
-            [content][meta-content] attribute's value and the <var>current
-            document</var>'s global.
-            </li>
-            <li>
-              <a>Enforce</a> the policy <var>policy</var>.
-            </li>
-          </ol>
-        </section>
-      </section>
-      <section>
-        <h2>Parse policy from <var>value</var> and <var>global</var></h2>
-        <p>Given a string (<var>value</var>) and [global object]
-        (<var>global</var>) this algorithm will return a <a>feature
-        policy</a>.</p>
-        <ol>
-          <li>Let <var>list</var> be the result of executing the algorithm
-          defined in Section 4 of [[!HTTP-JFV]]. If that algorithm results in
-          an error, abort these steps.</li>
-          <li>Let <var>policy</var> be an empty list.</li>
-          <li>For each <var>item</var> in <var>list</var>:
-            <ol>
-              <li>Let <var>target</var> be an empty list.</li>
-              <li>If <var>item</var> has a <a>target member</a> whose value is
-              an array, then for each <var>origin</var> in the array:
-                <ol>
-                  <li>If <var>origin</var> is an [ASCII case-insensitive] match
-                  for "`self`", let <var>result</var> be the
-                  <var>global</var>'s origin.</li>
-                  <li>Otherwise, let <var>result</var> be the result of
-                  executing the [URL parser] on <var>origin</var></li>
-                  <li>If <var>result</var> is not `failure`, then append the
-                  [origin of <var>result</var>][origin-of-url] to
-                  <var>target</var>.</li>
-                </ol>
-              </li>
-              <li>If <var>target</var> is still an empty list, set
-              <var>target</var> to "`\*`".</li>
-              <li>Let <var>disable</var> be the result of executing <a href=
-              "#parse-disable-features"></a> on the <var>item</var>'s
-              <a>disable member</a>'s value.
-              </li>
-              <li>Let <var>enable</var> be the result of executing <a href=
-              "#parse-enable-features"></a> on the <var>item</var>'s <a>enable
-              member</a>'s value.
-              </li>
-              <li>Let <var>tuple</var> be a new <a>directive</a> tuple whose
-              values are set as follows:
-                <dl>
-                  <dt>"`target`"</dt>
-                  <dd>Set to <var>target</var>.</dd>
-                  <dt>"`disable`"</dt>
-                  <dd>Set to <var>disable</var>.</dd>
-                  <dt>"`enable`"</dt>
-                  <dd>Set to <var>enable</var>.</dd>
-                </dl>
-              </li>
-              <li>Append <var>tuple</var> to <var>policy</var>.</li>
-            </ol>
-          </li>
-          <li>Return <var>policy</var>.</li>
-        </ol>
-      </section>
+     <h3 class="heading settled" data-level="4.4" id="declared-policies"><span class="secno">4.4. </span><span class="content">Declared policies</span><a class="self-link" href="#declared-policies"></a></h3>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="declared policy|declared feature policy" data-noexport="" id="declared-policy">declared
+    policy</dfn> is a set of <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-2">policy directives</a>, which may be the empty
+    set.</p>
+     <p>The <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-3">declared policy</a> is represented in HTTP headers and HTML
+    attributes as a JSON string.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is considered <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-policy-aware">feature-policy-aware</dfn> if it has a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-4">declared policy</a> delivered
+    via a Feature-Policy HTTP header.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is which is not <a data-link-type="dfn" href="#feature-policy-aware" id="ref-for-feature-policy-aware-1">feature-policy-aware</a> is considered <dfn data-dfn-type="dfn" data-noexport="" id="feature-policy-oblivious">feature-policy-oblivious<a class="self-link" href="#feature-policy-oblivious"></a></dfn>.</p>
     </section>
     <section>
-      <h2>Features</h2>
-      <p>This section defines <dfn>features</dfn> and their effect when applied
-      via a <a>directive</a> as part of a <a>feature policy</a>.</p>
-      <p>The following table summarizes <a>features</a> defined by this
-      specification, by their corresponding keywords. This table is
-      non-normative; the actual definitions are given in the following
-      sections.</p>
-      <table>
-        <thead>
-          <tr>
-            <th rowspan="2">Feature</th>
-            <th colspan="2">
-              <a>Enable policy</a>
-            </th>
-            <th rowspan="2">
-              <a>Disable policy</a>
-            </th>
-            <th rowspan="2">Brief description</th>
-          </tr>
-          <tr>
-            <th>top-level context</th>
-            <th>nested context</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a>cookie</a>
-            </td>
-            <td>`\*`</td>
-            <td>`\*`</td>
-            <td>`null`</td>
-            <td>Controls access to `document.cookie`.</td>
-          </tr>
-          <tr>
-            <td>
-              <a>domain</a>
-            </td>
-            <td>`\*`</td>
-            <td>`\*`</td>
-            <td>`null`</td>
-            <td>Controls access to `document.domain`.</td>
-          </tr>
-          <tr>
-            <td>
-              <a>docwrite</a>
-            </td>
-            <td>`\*`</td>
-            <td>`\*`</td>
-            <td>`null`</td>
-            <td>Controls access to `document.write`, `document.writeln`.</td>
-          </tr>
-          <tr>
-            <td>
-              <a>...</a>
-            </td>
-            <td>...</td>
-            <td>...</td>
-            <td>...</td>
-            <td>...</td>
-          </tr>
-          <tr>
-            <td>
-              <a>geolocation</a>
-            </td>
-            <td>`self`</td>
-            <td>`null`</td>
-            <td>`null`</td>
-            <td>Controls access to [Geolocation interface].</td>
-          </tr>
-          <tr>
-            <td>
-              <a>midi</a>
-            </td>
-            <td>`self`</td>
-            <td>`null`</td>
-            <td>`null`</td>
-            <td>Controls access to [requestMIDIAccess method].</td>
-          </tr>
-          <tr>
-            <td>
-              <a>notifications</a>
-            </td>
-            <td>`self`</td>
-            <td>`null`</td>
-            <td>`null`</td>
-            <td>Controls access to [Notification interface].</td>
-          </tr>
-          <tr>
-            <td>
-              <a>payment</a>
-            </td>
-            <td>`self`</td>
-            <td>`null`</td>
-            <td>`null`</td>
-            <td>Controls access to [PaymentRequest interface].</td>
-          </tr>
-          <tr>
-            <td>
-              <a>push</a>
-            </td>
-            <td>`self`</td>
-            <td>`null`</td>
-            <td>`null`</td>
-            <td>Controls access to [PushManager interface].</td>
-          </tr>
-          <tr>
-            <td>
-              <a>sync-script</a>
-            </td>
-            <td>`\*`</td>
-            <td>`\*`</td>
-            <td>`null`</td>
-            <td>Controls use of synchronous `script` elements.</td>
-          </tr>
-          <tr>
-            <td>
-              <a>sync-xhr</a>
-            </td>
-            <td>`\*`</td>
-            <td>`\*`</td>
-            <td>`null`</td>
-            <td>Controls access to synchronous `XMLHttpRequest` API.</td>
-          </tr>
-          <tr>
-            <td>
-              <a>usermedia</a>
-            </td>
-            <td>`self`</td>
-            <td>`null`</td>
-            <td>`null`</td>
-            <td>Controls access to [NavigatorUserMedia interface].</td>
-          </tr>
-          <tr>
-            <td>
-              <a>vibrate</a>
-            </td>
-            <td>`self`</td>
-            <td>`null`</td>
-            <td>`null`</td>
-            <td>Controls access to [vibrate method].</td>
-          </tr>
-          <tr>
-            <td>
-              <a>webrtc</a>
-            </td>
-            <td>`\*`</td>
-            <td>`\*`</td>
-            <td>`null`</td>
-            <td>Controls access to [RTCPeerConnection interface].</td>
-          </tr>
-        </tbody>
-      </table>
-      <section>
-        <h2><dfn>`cookie`</dfn></h2>
-        <pre class="idl">
-partial interface Document {
-  [Feature=cookie] attribute USVString cookie;
-};</pre>
-        <p>The <a>cookie</a> keyword controls whether the [cookie attribute] is
-        [exposed] for [current global object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `\*` for [top-level browsing
-          context], and `\*` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`domain`</dfn></h2>
-        <pre class="idl">
-partial interface Document {
-  [Feature=domain] attribute USVString domain;
-};</pre>
-        <p>The <a>domain</a> keyword controls whether the [domain attribute] is
-        [exposed] for [current global object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `\*` for [top-level browsing
-          context], and `\*` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`docwrite`</dfn></h2>
-        <pre class="idl">
-partial interface Document {
-  [CEReactions, Feature=docwrite] void write(DOMString... text);
-  [CEReactions, Feature=docwrite] void writeln(DOMString... text);
-};</pre>
-        <p>The <a>docwrite</a> keyword controls whether the [document.write]
-        and [document.writeln] methods are [exposed] for [current global
-        object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `\*` for [top-level browsing
-          context], and `\*` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`geolocation`</dfn></h2>
-        <pre class="idl">
-partial interface Navigator {
-  [Feature=geolocation] readonly attribute Geolocation geolocation;
-};</pre>
-        <p>The <a>geolocation</a> keyword controls whether the [Geolocation
-        interface] ([[!GEOLOCATION-API]]) is [exposed] for [current global
-        object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `self` for [top-level
-          browsing context], and `null` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`midi`</dfn></h2>
-        <pre class="idl">
-partial interface Navigator {
-  [Feature=midi] Promise&lt;MIDIAccess&gt; requestMIDIAccess (optional MIDIOptions options);
-};</pre>
-        <p>The <a>midi</a> keyword controls whether the [requestMIDIAccess
-        method] ([[!WEBMIDI]]) is [exposed] for [current global object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `self` for [top-level
-          browsing context], and `null` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`notifications`</dfn></h2>
-        <pre class="idl">
-[Constructor(DOMString title, optional NotificationOptions options),
-Feature=notifications]
-interface Notification : EventTarget {};</pre>
-        <p>The <a>notifications</a> keyword controls whether the [Notification
-        interface] ([[!NOTIFICATIONS]]) is [exposed] for [current global
-        object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `self` for [top-level
-          browsing context], and `null` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`payment`</dfn></h2>
-        <pre class="idl">
-[Constructor(sequence&lt;PaymentMethodData&gt; methodData, PaymentDetails details, optional PaymentOptions options),
- SecureContext, Feature=payment]
-interface PaymentRequest : EventTarget {};</pre>
-        <p>The <a>payment</a> keyword controls whether the [PaymentRequest
-        interface] ([[!PAYMENT-REQUEST]]) is [exposed] for [current global
-        object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `self` for [top-level
-          browsing context], and `null` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`push`</dfn></h2>
-        <pre class="idl">
-partial interface ServiceWorkerRegistration {
-  [Feature=push] readonly attribute PushManager pushManager;
-};
-
-[Feature=push]
-interface PushManager {};
+     <h3 class="heading settled" data-level="4.5" id="header-policies"><span class="secno">4.5. </span><span class="content">Header policies</span><a class="self-link" href="#header-policies"></a></h3>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="header-policy">header policy</dfn> is a declared policy delivered via an HTTP
+    header with the document, or in an HTML meta element in the document’s
+    HEAD. These form the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-2">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-5">declared
+    policy</a>.</p>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="4.6" id="container-policies"><span class="secno">4.6. </span><span class="content">Container policies</span><a class="self-link" href="#container-policies"></a></h3>
+     <p>In addition to the <a data-link-type="dfn" href="#header-policy" id="ref-for-header-policy-1">header policy</a>, each frame has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="container policy" data-noexport="" id="container-policy">container
+    policy</dfn>, which is a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-3">policy directive</a>, which may be empty. The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-1">container policy</a> can set by attributes on the browsing context
+    container.</p>
+     <p>The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-2">container policy</a> for a frame influences the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-2">inherited
+    policy</a> of any document loaded into that frame. (See <a href="#define-inherited-policy">§8.8 Define an inherited policy for
+    feature</a>)</p>
+     <div class="note" role="note"> Currently, the <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-3">container policy</a> cannot be set directly, but is
+      indirectly set by <code>iframe</code> "<a href="#iframe-allowfullscreen-attribute"><code>allowfullscreen</code></a>",
+      "<a href="#iframe-allowpaymentrequest-attribute"><code>allowpaymentrequest</code></a>",
+      and "<a href="#iframe-allow-attribute"><code>allow</code></a>"
+      attributes. Future revisions to this spec may introduce a mechanism to
+      explicitly declare the full <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-4">container policy</a>. </div>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="4.7" id="policy-directives"><span class="secno">4.7. </span><span class="content">Policy directives</span><a class="self-link" href="#policy-directives"></a></h3>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="policy directive|policy directives" data-noexport="" id="policy-directive">policy
+    directive</dfn> is a dictionary, mapping <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-1">feature names</a> to
+    corresponding <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-2">allowlists</a> of origins.</p>
+     <p>The following sections define the set of known <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-2">feature names</a>.
+    Future versions of this document may define additional such names, as user
+    agents ignore policy directives with unrecognized names when parsing the
+    policy.</p>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="4.8" id="allowlists"><span class="secno">4.8. </span><span class="content">Allowlists</span><a class="self-link" href="#allowlists"></a></h3>
+     <p>A feature policy <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="allowlist|allowlists" data-noexport="" id="allowlist">allowlist</dfn> is
+    a set of origins. An <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-3">allowlist</a> may be <em>empty</em>, in which case
+    it does not match any origin, or it may contain a list of origins, or it
+    may match every origin. When defining an allowlist in a policy, the special
+    origin "self" may be used, which refers to the origin of document which the
+    policy is associated with.</p>
+     <p>An <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-4">allowlist</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="matches">matches</dfn> an origin <var>o</var> if it
+    matches every origin, or if it contains an origin which is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">same origin-domain</a> with <var>o</var>.</p>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="4.9" id="default-allowlists"><span class="secno">4.9. </span><span class="content">Default Allowlists</span><a class="self-link" href="#default-allowlists"></a></h3>
+     <p>Every feature controlled by policy has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>, which is an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-5">allowlist</a>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-2">default allowlist</a> controls the origins which
+    are allowed to access the feature when used in a top-level document with no
+    declared policy, and also determines whether access to a feature is
+    automatically delegated to child documents.</p>
+     <p>Features are currently defined to have one of these three <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-3">default
+    allowlists</a>:</p>
+     <dl>
+      <dt>["<code>*</code>"]
+      <dd>The feature is allowed at the top level by default, and when allowed,
+      is allowed by default to documents in child frames.
+      <dt>["<code>self</code>"]
+      <dd>The feature is allowed at the top level by default, and when allowed,
+      is allowed by default to same-origin domain documents in child frames,
+      but is disallowed by default in cross-origin documents in child
+      frames.
+      <dt>[]
+      <dd>The feature is disallowed at the top level by default, and is also
+      disallowed by default to documents in child frames.
+     </dl>
+    </section>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="5" id="serialization"><span class="secno">5. </span><span class="content">Feature Policy Serialization</span><a class="self-link" href="#serialization"></a></h2>
+    <section>
+     <h3 class="heading settled" data-level="5.1" id="json-serialization"><span class="secno">5.1. </span><span class="content">JSON serialization</span><a class="self-link" href="#json-serialization"></a></h3>
+     <p>Declared Policies are represented in HTTP headers and in HTML attributes
+    as JSON text <a data-link-type="biblio" href="#biblio-rfc7159">[RFC7159]</a>.</p>
+     <div class="railroad">
+      <svg class="railroad-diagram" height="237" viewBox="0 0 900 237" width="900">
+       <g transform="translate(.5 .5)">
+        <path d="M 20 46 v 20 m 10 -20 v 20 m -10 -10 h 20.5"></path>
+        <path d="M40 56h10"></path>
+        <g>
+         <path d="M50 56h0"></path>
+         <path d="M850 56h0"></path>
+         <g class="terminal">
+          <path d="M50 56h0"></path>
+          <path d="M78 56h0"></path>
+          <rect height="22" rx="10" ry="10" width="28" x="50" y="45"></rect>
+          <a href="">
+           <text x="64" y="60">[</text>
+           <text x="64" y="60">[</text>
+          </a>
+         </g>
+         <path d="M78 56h10"></path>
+         <g>
+          <path d="M88 56h0"></path>
+          <path d="M812 56h0"></path>
+          <path d="M88 56a10 10 0 0 0 10 -10v-16a10 10 0 0 1 10 -10"></path>
+          <g>
+           <path d="M108 20h684"></path>
+          </g>
+          <path d="M792 20a10 10 0 0 1 10 10v16a10 10 0 0 0 10 10"></path>
+          <path d="M88 56h20"></path>
+          <g>
+           <path d="M108 56h0"></path>
+           <path d="M792 56h0"></path>
+           <path d="M108 56h10"></path>
+           <g>
+            <path d="M118 56h0"></path>
+            <path d="M782 56h0"></path>
+            <g class="terminal">
+             <path d="M118 56h0"></path>
+             <path d="M146 56h0"></path>
+             <rect height="22" rx="10" ry="10" width="28" x="118" y="45"></rect>
+             <a href="">
+              <text x="132" y="60">{</text>
+              <text x="132" y="60">{</text>
+             </a>
+            </g>
+            <path d="M146 56h10"></path>
+            <g>
+             <path d="M156 56h0"></path>
+             <path d="M744 56h0"></path>
+             <path d="M156 56a10 10 0 0 0 10 -10v-8a10 10 0 0 1 10 -10"></path>
+             <g>
+              <path d="M176 28h548"></path>
+             </g>
+             <path d="M724 28a10 10 0 0 1 10 10v8a10 10 0 0 0 10 10"></path>
+             <path d="M156 56h20"></path>
+             <g>
+              <path d="M176 56h0"></path>
+              <path d="M724 56h0"></path>
+              <path d="M176 56h10"></path>
+              <g>
+               <path d="M186 56h0"></path>
+               <path d="M714 56h0"></path>
+               <g class="terminal">
+                <path d="M186 56h0"></path>
+                <path d="M214 56h0"></path>
+                <rect height="22" rx="10" ry="10" width="28" x="186" y="45"></rect>
+                <a href="">
+                 <text x="200" y="60">"</text>
+                 <text x="200" y="60">"</text>
+                </a>
+               </g>
+               <path d="M214 56h10"></path>
+               <path d="M224 56h10"></path>
+               <g class="non-terminal">
+                <path d="M234 56h0"></path>
+                <path d="M350 56h0"></path>
+                <rect height="22" width="116" x="234" y="45"></rect>
+                <a href="">
+                 <text x="292" y="60">feature-name</text>
+                 <text x="292" y="60">feature-name</text>
+                </a>
+               </g>
+               <path d="M350 56h10"></path>
+               <path d="M360 56h10"></path>
+               <g class="terminal">
+                <path d="M370 56h0"></path>
+                <path d="M422 56h0"></path>
+                <rect height="22" rx="10" ry="10" width="52" x="370" y="45"></rect>
+                <a href="">
+                 <text x="396" y="60">": [</text>
+                 <text x="396" y="60">": [</text>
+                </a>
+               </g>
+               <path d="M422 56h10"></path>
+               <g>
+                <path d="M432 56h0"></path>
+                <path d="M676 56h0"></path>
+                <path d="M432 56a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+                <g>
+                 <path d="M452 36h204"></path>
+                </g>
+                <path d="M656 36a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+                <path d="M432 56h20"></path>
+                <g>
+                 <path d="M452 56h0"></path>
+                 <path d="M656 56h0"></path>
+                 <path d="M452 56h10"></path>
+                 <g>
+                  <path d="M462 56h0"></path>
+                  <path d="M646 56h0"></path>
+                  <g class="terminal">
+                   <path d="M462 56h0"></path>
+                   <path d="M490 56h0"></path>
+                   <rect height="22" rx="10" ry="10" width="28" x="462" y="45"></rect>
+                   <a href="">
+                    <text x="476" y="60">"</text>
+                    <text x="476" y="60">"</text>
+                   </a>
+                  </g>
+                  <path d="M490 56h10"></path>
+                  <g>
+                   <path d="M500 56h0"></path>
+                   <path d="M608 56h0"></path>
+                   <path d="M500 56h20"></path>
+                   <g class="non-terminal">
+                    <path d="M520 56h0"></path>
+                    <path d="M588 56h0"></path>
+                    <rect height="22" width="68" x="520" y="45"></rect>
+                    <a href="">
+                     <text x="554" y="60">origin</text>
+                     <text x="554" y="60">origin</text>
+                    </a>
+                   </g>
+                   <path d="M588 56h20"></path>
+                   <path d="M500 56a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path>
+                   <g class="terminal">
+                    <path d="M520 86h8"></path>
+                    <path d="M580 86h8"></path>
+                    <rect height="22" rx="10" ry="10" width="52" x="528" y="75"></rect>
+                    <a href="">
+                     <text x="554" y="90">self</text>
+                     <text x="554" y="90">self</text>
+                    </a>
+                   </g>
+                   <path d="M588 86a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path>
+                   <path d="M500 56a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path>
+                   <g class="terminal">
+                    <path d="M520 116h20"></path>
+                    <path d="M568 116h20"></path>
+                    <rect height="22" rx="10" ry="10" width="28" x="540" y="105"></rect>
+                    <a href="">
+                     <text x="554" y="120">*</text>
+                     <text x="554" y="120">*</text>
+                    </a>
+                   </g>
+                   <path d="M588 116a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path>
+                  </g>
+                  <path d="M608 56h10"></path>
+                  <g class="terminal">
+                   <path d="M618 56h0"></path>
+                   <path d="M646 56h0"></path>
+                   <rect height="22" rx="10" ry="10" width="28" x="618" y="45"></rect>
+                   <a href="">
+                    <text x="632" y="60">"</text>
+                    <text x="632" y="60">"</text>
+                   </a>
+                  </g>
+                 </g>
+                 <path d="M646 56h10"></path>
+                 <path d="M462 56a10 10 0 0 0 -10 10v70a10 10 0 0 0 10 10"></path>
+                 <g class="terminal">
+                  <path d="M462 146h78"></path>
+                  <path d="M568 146h78"></path>
+                  <rect height="22" rx="10" ry="10" width="28" x="540" y="135"></rect>
+                  <a href="">
+                   <text x="554" y="150">,</text>
+                   <text x="554" y="150">,</text>
+                  </a>
+                 </g>
+                 <path d="M646 146a10 10 0 0 0 10 -10v-70a10 10 0 0 0 -10 -10"></path>
+                </g>
+                <path d="M656 56h20"></path>
+               </g>
+               <path d="M676 56h10"></path>
+               <g class="terminal">
+                <path d="M686 56h0"></path>
+                <path d="M714 56h0"></path>
+                <rect height="22" rx="10" ry="10" width="28" x="686" y="45"></rect>
+                <a href="">
+                 <text x="700" y="60">]</text>
+                 <text x="700" y="60">]</text>
+                </a>
+               </g>
+              </g>
+              <path d="M714 56h10"></path>
+              <path d="M186 56a10 10 0 0 0 -10 10v100a10 10 0 0 0 10 10"></path>
+              <g class="terminal">
+               <path d="M186 176h250"></path>
+               <path d="M464 176h250"></path>
+               <rect height="22" rx="10" ry="10" width="28" x="436" y="165"></rect>
+               <a href="">
+                <text x="450" y="180">,</text>
+                <text x="450" y="180">,</text>
+               </a>
+              </g>
+              <path d="M714 176a10 10 0 0 0 10 -10v-100a10 10 0 0 0 -10 -10"></path>
+             </g>
+             <path d="M724 56h20"></path>
+            </g>
+            <path d="M744 56h10"></path>
+            <g class="terminal">
+             <path d="M754 56h0"></path>
+             <path d="M782 56h0"></path>
+             <rect height="22" rx="10" ry="10" width="28" x="754" y="45"></rect>
+             <a href="">
+              <text x="768" y="60">}</text>
+              <text x="768" y="60">}</text>
+             </a>
+            </g>
+           </g>
+           <path d="M782 56h10"></path>
+           <path d="M118 56a10 10 0 0 0 -10 10v130a10 10 0 0 0 10 10"></path>
+           <g class="terminal">
+            <path d="M118 206h318"></path>
+            <path d="M464 206h318"></path>
+            <rect height="22" rx="10" ry="10" width="28" x="436" y="195"></rect>
+            <a href="">
+             <text x="450" y="210">,</text>
+             <text x="450" y="210">,</text>
+            </a>
+           </g>
+           <path d="M782 206a10 10 0 0 0 10 -10v-130a10 10 0 0 0 -10 -10"></path>
+          </g>
+          <path d="M792 56h20"></path>
+         </g>
+         <path d="M812 56h10"></path>
+         <g class="terminal">
+          <path d="M822 56h0"></path>
+          <path d="M850 56h0"></path>
+          <rect height="22" rx="10" ry="10" width="28" x="822" y="45"></rect>
+          <a href="">
+           <text x="836" y="60">]</text>
+           <text x="836" y="60">]</text>
+          </a>
+         </g>
+        </g>
+        <path d="M850 56h10"></path>
+        <path d="M 860 56 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+       </g>
+      </svg>
+     </div>
+     <p><code>origin</code> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">ASCII serialization of an origin</a>.</p>
+     <p><code>feature-name</code> is a JSON string.</p>
+     <div class="note" role="note"> The string "<code>self</code>" may be used as an origin in an allowlist.
+      When it is used in this way, it will refer to the origin of the document
+      which contains the feature policy. </div>
+     <div class="note" role="note"> The begin-array and end-array marks ("[" and "]") are semantically part
+      of the JSON representation of the declared policy, but they do not appear
+      in the HTTP headers or meta elements. Those characters are added to the
+      HTTP headers before parsing, so that the entire set of concatenated
+      headers are parsed as a single array. </div>
+    </section>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="6" id="delivery"><span class="secno">6. </span><span class="content">Delivery</span><a class="self-link" href="#delivery"></a></h2>
+    <section>
+     <h3 class="heading settled" data-level="6.1" id="feature-policy-http-header-field"><span class="secno">6.1. </span><span class="content">Feature-Policy HTTP Header
+    Field</span><a class="self-link" href="#feature-policy-http-header-field"></a></h3>
+     <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="feature-policy-header" data-noexport="" id="feature-policy-header">Feature-Policy</dfn> HTTP header
+    field can be used in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a> (server to client) to communicate the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-3">feature policy</a> that should be enforced by the client.</p>
+     <p>The header’s value is the <a href="#json-serialization">§5.1 JSON serialization</a> of the
+    elements of the <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-6">declared policy</a>:</p>
+<pre class="abnf">FeaturePolicy = 1#json-field-value
+          ; See Section 2 of [[HTTP-JFV]], and Section 2 of [[RFC7159]]
 </pre>
-        <p>The <a>push</a> keyword controls whether the [PushManager interface]
-        ([[!PUSH-API]]) is [exposed] for [current global object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `self` for [top-level
-          browsing context], and `null` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`sync-script`</dfn></h2>
-        <p>The <a>sync-script</a> keyword controls use of synchronous `script`
-        elements, as defined in <a href="#integration-with-html"></a>. When
-        this feature is disabled, such scripts are ignored by the user
-        agent.</p>
-        <div class="example">
-          <p>Given the following header:</p>
-          <pre>
-  <a>Feature-Policy</a>: {"<a data-lt=
-"disable member">disable</a>":["<a>sync-script</a>"]}</pre>
-          <p>The following HTML will not result in execution of `script1.js`,
-          as it has neither a [`defer`] nor an [`async`] attribute. The
-          remaining scripts will execute normally because they have their
-          [non-blocking] flag set.</p>
-          <pre>
-  &lt;script src="/script1.js"&gt;&lt;/script&gt;
-  &lt;script src="/script2.js" <strong>async</strong>&gt;&lt;/script&gt;
-  &lt;script src="/script3.js" <strong>defer</strong>&gt;&lt;/script&gt;
-  &lt;script&gt;
-    const scriptEl = document.createElement("script");
-    scriptEl.src = "/script4.js";
-    document.body.appendChild(scriptEl);
-  &lt;/script&gt;</pre>
-        </div>
-      </section>
-      <section>
-        <h2><dfn>`sync-xhr`</dfn></h2>
-        <p>The <a>sync-xhr</a> keyword controls use of synchronous
-        `XMLHttpRequest` API, as defined in <a href=
-        "#integration-with-xmlhttprequest"></a>. When [open() method](xhr-open)
-        is called with <var>async</var> argument set to <var>false</var>, an
-        `InvalidAccessError` except will be thrown.</p>
-        <div class="example">
-          <p>Given the following header:</p>
-          <pre>
-  <a>Feature-Policy</a>: {"<a data-lt=
-"disable member">disable</a>":["<a>sync-xhr</a>"]}</pre>
-          <p>The following JavaScript code will throw a `InvalidAccessError`
-          exception:</p>
-          <pre>
-  var xhr = new XMLHttpRequest();
-  xhr.open("GET", "/foo", false);</pre>
-        </div>
-      </section>
-      <section>
-        <h2><dfn>`usermedia`</dfn></h2>
-        <pre class="idl">
-[Exposed=Window, NoInterfaceObject, Feature=usermedia]
-interface NavigatorUserMedia {
-    [SameObject] readonly attribute MediaDevices mediaDevices;
+     <p>When the user agent receives a <code>Feature-Policy</code> header field,
+    it MUST <a href="#process-response-policy">process</a> and <a data-link-type="dfn" href="#enforce" id="ref-for-enforce-1">enforce</a> the serialized policy as described in <a href="#integration-with-html">§7.1 Integration with HTML</a>.</p>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="6.2" id="feature-policy-meta-element"><span class="secno">6.2. </span><span class="content">The <code>meta</code> element</span><a class="self-link" href="#feature-policy-meta-element"></a></h3>
+     <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> may deliver a policy via one or more HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> elements whose <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a></code> attributes are an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> match for the string
+    "<code>Feature-Policy</code>". For example:</p>
+<pre class="example" id="example-64676863"><a class="self-link" href="#example-64676863"></a>&lt;meta http-equiv="Feature-Policy" content='{"webrtc": [], "geolocation": ["https://example.com"]}'></pre>
+     <p>The <code>meta</code> policy is processed as defined in <a href="#process-meta-policy">§7.1.1 Process meta policy</a> and modifications to the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">content</a></code> attribute of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> element after the
+    element has been parsed MUST be ignored.</p>
+     <p>To ensure that the policy can be applied before any scripts are able to
+    execute within the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>, the following
+    restrictions apply to <code>meta</code> policy:</p>
+     <ul>
+      <li>The elements containing the <code>meta</code> policy MUST be
+      serialized completely within the first 1024 bytes of the document.
+      <li>The elements containing the <code>meta</code> policy MUST appear
+        before any <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> elements.
+     </ul>
+     <div class="note" role="note"> Since JSON serialization requires U+0022 QUOTATION MARK as a string
+      delimiter, it is recommended that the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">content</a></code> attribute
+      of the Feature Policy <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code> tag be delimited with U+0027 APOSTROPHE, to
+      avoid having to encode JSON delimeters as "<code>&amp;quot;</code>" </div>
+     <div class="issue" id="issue-7c854c21"><a class="self-link" href="#issue-7c854c21"></a> TODO: Ensure that inserting this element after scripts can run has no
+      effect. </div>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="6.3" id="iframe-allow-attribute"><span class="secno">6.3. </span><span class="content">The <code>allow</code> attribute of the <code>iframe</code> element</span><a class="self-link" href="#iframe-allow-attribute"></a></h3>
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmliframeelement">HTMLIFrameElement</a> {
+    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#PutForwards">PutForwards</a>=<a class="n idl-code" data-link-type="attribute" href="https://dom.spec.whatwg.org/#dom-domtokenlist-value">value</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#domtokenlist">DOMTokenList</a> <dfn class="nv idl-code" data-dfn-for="HTMLIFrameElement" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMTokenList" id="dom-htmliframeelement-allow">allow<a class="self-link" href="#dom-htmliframeelement-allow"></a></dfn>;
 };</pre>
-        <p>The <a>usermedia</a> keyword controls whether the
-        [NavigatorUserMedia interface] ([[!MEDIACAPTURE-API]]) is [exposed] for
-        [current global object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `self` for [top-level
-          browsing context], and `null` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`vibrate`</dfn></h2>
-        <pre class="idl">
-partial interface Navigator {
-  [Feature=vibrate] boolean vibrate(VibratePattern pattern);
-};</pre>
-        <p>The <a>vibrate</a> keyword controls whether the [vibrate method]
-        ([[!VIBRATION]]) is [exposed] for [current global object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `self` for [top-level
-          browsing context], and `null` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2><dfn>`webrtc`</dfn></h2>
-        <pre class="idl">
-[Constructor(optional RTCConfiguration configuration), Feature=webrtc]
-interface RTCPeerConnection : EventTarget {};</pre>
-        <p>The <a>webrtc</a> keyword controls whether the [RTCPeerConnection
-        interface] ([[!WEBRTC]]) is [exposed] for [current global object].</p>
-        <ol>
-          <li>The default <a>enable policy</a> is `\*` for [top-level browsing
-          context], and `\*` for [nested browsing context].
-          </li>
-          <li>The default <a>disable policy</a> is `null`.
-          </li>
-        </ol>
-      </section>
+     <p><code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> elements have an "<code>allow</code>" attribute, which
+    contains an unordered set of unique space-separated tokens that are ASCII
+    case-insensitive. The allowed values are names of features. Unrecognized
+    values must be ignored.</p>
+     <p>When not empty, the "<code>allow</code>" attribute will result in adding
+    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-6">allowlist</a> for each recognized feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-5">container
+    policy</a>, when it is contructed.</p>
+     <p>The <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-7">allowlist</a> will contain a single origin, which is the origin
+    of URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-src">src</a></code> attribute.</p>
     </section>
-  </section>
-  <section>
-    <h2>Disable Policy</h2>
-    <p>The <dfn>disable policy</dfn> allows a developer to turn off certain
-    features for a <code>Document</code> or <code>Worker</code>.</p>
     <section>
-      <h2>Processing</h2>
-      <section>
-        <h2>Parse disable features</h2>
-        <p>Given a <var>list</var>, this algorithm returns a list of
-        <a>features</a>, which may be empty.</p>
-        <ol>
-          <li>Let <var>valid-features</var> be an empty list.</li>
-          <li>If <var>list</var> is <var>null</var> or empty, return
-          <var>valid-features</var>.</li>
-          <li>For each <var>item</var> in <var>list</var>:
-            <ol>
-              <li>Convert <var>item</var> to ASCII-lowercase.</li>
-              <li>If <var>item</var>'s string value is not one of the
-              <a>features</a>, ignore <var>item</var>, and continue to the next
-              item.
-              </li>
-              <li>Append <var>item</var> to <var>valid-features</var>.</li>
-            </ol>
-          </li>
-          <li>Return <var>valid-features</var>.</li>
-        </ol>
-      </section>
+     <h3 class="heading settled" data-level="6.4" id="legacy-attributes"><span class="secno">6.4. </span><span class="content">Additional attributes to support legacy
+    features</span><a class="self-link" href="#legacy-attributes"></a></h3>
+     <p>Some features controlled by Feature Policy have existing iframe
+    attributes defined. This specification redefines these attributes to act as
+    declared policies for the iframe element.</p>
+     <section>
+      <h4 class="heading settled" data-level="6.4.1" id="iframe-allowfullscreen-attribute"><span class="secno">6.4.1. </span><span class="content">allowfullscreen</span><a class="self-link" href="#iframe-allowfullscreen-attribute"></a></h4>
+      <p>The "<code>allowfullscreen</code>" iframe attribute controls access to <code class="idl"><a data-link-type="idl">requestFullscreen()</a></code>.</p>
+      <p>If the iframe element has an "<code>allow</code>" attribute whose
+      value contains the token "<code>fullscreen</code>", then the
+      "<code>allowfullscreen</code> attribute should have no effect.</p>
+      <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
+      will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-8">allowlist</a> of ["<code>*</code>"] for the
+      "fullscreen" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-6">container policy</a>, when it is
+      constructed.</p>
+      <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
+        allow="fullscreen"></code>, and is for compatibility with existing
+        uses of <code>allowfullscreen</code>. If <code>allow="fullscreen"</code> and <code>allowfullscreen</code> are
+        both present on an iframe element, then the more restrictive allowlist
+        of <code>allow="fullscreen"</code> will be used. </div>
+     </section>
+     <section>
+      <h4 class="heading settled" data-level="6.4.2" id="iframe-allowpaymentrequest-attribute"><span class="secno">6.4.2. </span><span class="content">allowpaymentrequest</span><a class="self-link" href="#iframe-allowpaymentrequest-attribute"></a></h4>
+      <p>The "<code>allowpaymentrequest</code>" iframe attribute controls
+      access to <a data-link-type="dfn">Payment interface</a>.</p>
+      <p>If the iframe element has an "<code>allow</code>" attribute whose
+      value contains the token "<code>payment</code>", then the
+      "<code>allowpaymentrequest</code> attribute should have no effect.</p>
+      <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
+      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-9">allowlist</a> of ["<code>*</code>"] for
+      the "payment" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-7">container policy</a>, when it is
+      constructed.</p>
+      <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
+        allow="payment"></code>, and is for compatibility with existing uses
+        of <code>allowpaymentrequest</code>. If <code>allow="payment"</code> and <code>allowpaymentrequest</code> are both present on an iframe
+        element, then the more restrictive allowlist of <code>allow="payment"</code> will be used. </div>
+     </section>
     </section>
-  </section>
-  <section>
-    <h2>Enable Policy</h2>
-    <p>The <dfn>enable policy</dfn> allows a developer to turn on certain
-    features for a <code>Document</code> or <code>Worker</code>.</p>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="7" id="integrations"><span class="secno">7. </span><span class="content">Integrations</span><a class="self-link" href="#integrations"></a></h2>
+    <p>This document defines a set of algorithms which other specifications will
+  use in order to implement the restrictions which Feature Policy defines. The
+  integrations are outlined here for clarity, but those external documents are
+  the normative references which ought to be consulted for detailed
+  information.</p>
     <section>
-      <h2>Processing</h2>
-      <section>
-        <h2>Parse enable features</h2>
-        <p>Given a <var>list</var>, this algorithm returns a list of
-        <a>features</a>, which may be empty.</p>
-        <ol>
-          <li>Let <var>valid-features</var> be an empty list.</li>
-          <li>If <var>list</var> is <var>null</var> or empty, return
-          <var>valid-features</var>.</li>
-          <li>For each <var>item</var> in <var>list</var>:
-            <ol>
-              <li>Convert <var>item</var> to ASCII-lowercase.</li>
-              <li>TODO... should we merge/refactor this with disable
-              parse?</li>
-              <li>Append <var>item</var> to <var>valid-features</var>.</li>
-            </ol>
-          </li>
-          <li>Return <var>valid-features</var>.</li>
-        </ol>
-      </section>
-    </section>
-  </section>
-  <section>
-    <h2>Integrations</h2>
-    <p>This document defines a set of algorithms which other specifications
-    will use in order to implement the restrictions which Feature Policy
-    defines. The integrations are outlined here for clarity, but those external
-    documents are the normative references which ought to be consulted for
-    detailed information.</p>
-    <section>
-      <h3>Integration with HTML</h3>
+     <h3 class="heading settled" data-level="7.1" id="integration-with-html"><span class="secno">7.1. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h3>
+     <ol>
+      <li> <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> objects have a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-4">Feature Policy</a>, which is populated via the <a href="#initialize-for-global">§8.7 Initialize global’s Feature
+    Policy from response</a> algorithm that is called during the
+        "Initialising a new <code>Document</code> object" and "Run a Worker"
+        algorithms. 
+      <li>
+       Replace the existing step 12 of "Initialising a new <code>Document</code> object" with the following step: 
+       <ul>
+        <li> <a href="#initialize-for-global">Initialize the feature policy</a> for the <code>Document</code> 
+       </ul>
+      <li>A <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-5">feature policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="enforce" data-noexport="" id="enforce">enforced</dfn> for
+      a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> by setting it as the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>'s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-6">Feature Policy</a>. 
+      <li>
+       <p>The "<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#allowed-to-use">allowed to use</a>" algorithm calls into <a href="#is-feature-enabled">§8.9 Is feature enabled in
+    global for origin?</a>, as follows:</p>
+       <ol>
+        <li>
+         Replace the current steps #3 and #4 with the following step: 
+         <ul>
+          <li>If <code>Document</code>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-7">feature policy</a> enables the
+              feature indicated by <code>allowattribute</code> for the origin
+              of <code>Document</code>, then return true. 
+         </ul>
+       </ol>
+     </ol>
+     <div class="issue" id="issue-7605d231"><a class="self-link" href="#issue-7605d231"></a> Monkey-patching! As soon as we know that this is the direction we wish to
+      pursue, upstream all of this. </div>
+     <section>
+      <h4 class="heading settled" data-level="7.1.1" id="process-meta-policy"><span class="secno">7.1.1. </span><span class="content">Process meta policy</span><a class="self-link" href="#process-meta-policy"></a></h4>
+      <div class="note" role="note"> This section extends HTML’s <code>meta</code> [pragma directives]. </div>
+      <strong>Feature policy state (http-equiv="feature-policy")</strong> 
+      <p>This pragma extends the declared feature policy for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code>.</p>
       <ol>
-        <li>
-          <code>Document</code> and <code>WorkerGlobalScope</code> objects have
-          a <dfn>Feature Policy List</dfn>, which is either the empty set or a
-          <a>feature policy</a>. This property is the empty set unless
-          otherwise specified, and is populated via the <a href=
-          "#initialize-for-global"></a> algorithm that is called during the
-          "Initialising a new <code>Document</code> object" and "Run a Worker"
-          algorithms.
-        </li>
-        <li>A <a>feature policy</a> is <dfn data-lt="enforce">enforced</dfn>
-        for a [global object] by inserting it into the [global object]'s
-        <a>Feature Policy list</a>.
-        </li>
-        <li>
-          <a>Feature policy</a> is enforced during <a href=
-          "#process-meta-policy">processing of the meta element’s
-          http-equiv</a>.
-        </li>
-        <li>
-          <p>The "[prepare a script]" algorithm calls into <a href=
-          "#is-feature-disabled"></a> algorithm to determine whether or not to
-          execute a script, as follows:</p>
-          <ol>
-            <li>Add the following step before the current step 10 (which is the
-            first of several "disabled" checks):
-              <ol>
-                <li>If the `script` element's "`non-blocking`" flag is unset,
-                the `script`'s type is "`classic`", and the <a href=
-                "#is-feature-disabled"></a> algorithm returns "`Disabled`" when
-                executed upon the `script` element's node document's global
-                object, then abort these steps at this point. The script is not
-                executed.
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </li>
+       <li>If the [meta] element has no [content] attribute, or if that
+        attribute’s value is the empty string, then abort these steps.
+       <li>If the [meta] element is not being inserted in into the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code>'s [head] element, or if is inserted after any [script] or
+        [link] elements, then abort these steps.
+       <li>Let document be the meta element’s node document
+       <li>Let <var>value</var> be the result of parsing the value of [meta]
+        element’s [content] attribute with a [JSON parser].
+       <li>If parsing returns an error, or <var>value</var> is not a [JSON
+        object], then abort these steps.
+       <li>Let <var>directive</var> be the result of running <a href="#parse-policy-directive">§8.3 Parse policy directive from
+    value and origin</a> on <var>value</var> and <var>document</var>’s [origin]. 
+       <li>Run <a href="#merge-directive-with-declared-policy">§8.4 Merge directive with declared
+    policy</a> with <var> directive</var> and document’s feature policy’s declared policy 
       </ol>
-      <div class="issue">
-        Monkey-patching! As soon as we know that this is the direction we wish
-        to persuse, upstream all of this.
-      </div>
-      <section>
-        <h4 id="initialize-for-global">Initialize <var>global</var>'s Feature
-        Policy from <var>response</var></h4>
-        <p>Given a [response] (<var>response</var>) and a global object
-        (<var>global</var>), this algorithm populates <var>global</var>'s
-        <a>Feature Policy List</a></p>
-        <ol>
-          <li>If <var>global</var> is a `Window` and its `Document` has a
-          parent browsing context or opener browsing context
-          (<var>context</var>):
-            <ol>
-              <li>Let <var>document</var> be the active document in
-              <var>context</var>.</li>
-              <li>For each <var>directive</var> in <var>document</var>'s
-              <a>Feature Policy List</a>:
-                <ol>
-                  <li>Add <var>directive</var> to <var>global</var>'s
-                  `Document`'s <a>Feature Policy List</a> if any of the
-                  following are true:
-                    <ol>
-                      <li>
-                        <var>directive</var>'s <a>target</a> is "`\*`"
-                      </li>
-                      <li>
-                        <var>directive</var>'s <a>target</a> is an array
-                        containing <var>global</var>'s origin
-                      </li>
-                      <li><var>response</var>'s url's scheme is a local
-                      scheme</li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          </li>
-          <li>If <var>global</var> is a `WorkerGlobalScope`:
-            <ol>
-              <li>For each <var>document</var> in <var>global</var>'s
-                <a href="https://html.spec.whatwg.org/multipage/workers.html#the-worker's-documents">
-                documents</a>:
-                <ol>
-                  <li>For each <var>directive</var> in <var>document</var>'s
-                  <a>Feature Policy List</a>:
-                    <ol>
-                      <li>Add <var>directive</var> to <var>global</var>'s
-                      <a>Feature Policy List</a> if either of the following are
-                      true:
-                        <ol>
-                          <li>
-                            <var>directive</var>'s <a>target</a> is "`\*`"
-                          </li>
-                          <li>
-                            <var>directive</var>'s <a>target</a> is an array
-                            containing <var>global</var>'s origin
-                          </li>
-                          <li><var>response</var>'s url's scheme is a local
-                          scheme</li>
-                        </ol>
-                      </li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          </li>
-          <li>Let <var>policy</var> be the result of executing <a href=
-          "#process-response-policy"></a> on <var>response</var> and
-          <var>global</var>.
-          </li>
+     </section>
+    </section>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="8" id="algorithms"><span class="secno">8. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
+    <section>
+     <h3 class="heading settled" data-level="8.1" id="process-response-policy"><span class="secno">8.1. </span><span class="content">Process response policy</span><a class="self-link" href="#process-response-policy"></a></h3>
+     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a> (<var>response</var>) and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>global</var>), this algorithm returns a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-7">declared feature
+    policy</a>.</p>
+     <ol>
+      <li>Abort these steps if the <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-request-header-list">header list</a> does
+      not contain a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name">name</a> is "<code>Feature-Policy</code>". 
+      <li>Let <var>header</var> be the concatenation of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-value">value</a>s of all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a> fields in <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-request-header-list">header list</a> whose name is
+      "<code>Feature-Policy</code>", separated by commas (according to
+      [RFC7230, 3.2.2]).
+      <li>Add a leading "[" U+005B character, and a trailing "]" U+005D
+      character to <var>header</var>.
+      <li>Let <var>feature policy</var> be the result of executing <a href="#parse-header">§8.2 Parse header from value and
+    origin</a> on <var>header</var> and <var>global</var>’s origin. 
+      <li>Return <var>feature policy</var>.
+     </ol>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="8.2" id="parse-header"><span class="secno">8.2. </span><span class="content">Parse header from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-header"></a></h3>
+     <p>Given a string (<var>value</var>) and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> (<var>origin</var>)
+    this algorithm will return a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-8">declared feature policy</a>.</p>
+     <ol>
+      <li>Let <var>policy</var> be an empty list.
+      <li>Let <var>list</var> be the result of parsing <var>value</var> with a <a data-link-type="dfn">JSON Parser</a>. If <var>value</var> cannot be parsed, return <var>policy</var>.
+      <li>Note: If <var>value</var> can be parsed, <var>list</var> must be a
+      valid <a data-link-type="dfn">JSON Array</a>.
+      <li>
+       For each <var>element</var> in <var>list</var>: 
+       <ol>
+        <li>If <var>element</var> is not a JSON object, then continue.
+        <li>Let <var>directive</var> be the result of executing <a href="#parse-policy-directive">§8.3 Parse policy directive from
+    value and origin</a> on <var>element</var> and <var>origin</var> 
+        <li>Run <a href="#merge-directive-with-declared-policy">§8.4 Merge directive with declared
+    policy</a> on <var> directive</var> and <var>policy</var>. 
+       </ol>
+      <li>Return <var>policy</var>.
+     </ol>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="8.3" id="parse-policy-directive"><span class="secno">8.3. </span><span class="content">Parse policy directive from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-policy-directive"></a></h3>
+     <p>Given a JSON object (<var>value</var>) and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> (<var>origin</var>) this algorithm will return a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-4">policy
+    directive</a>.</p>
+     <ol>
+      <li>Let <var>directive</var> be a new dictionary, mapping features to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-10">allowlist</a>s. 
+      <li>
+       For each <var>key</var> and associated <var>targetlist</var> in <var>value</var>: 
+       <ol>
+        <li>If <var>key</var> is not equal to the name of any recognized
+          feature, then continue.
+        <li>Let <var>feature</var> be the feature named by <var>key</var>.
+        <li>If <var>targetlist</var> is not an array, then continue.
+        <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-11">allowlist</a>. 
+        <li>If <var>targetlist</var> contains the string "<code>*</code>",
+          set <var>allowlist</var> to match every origin.
+        <li>
+         Otherwise, for each <var>element</var> in <var>targetlist</var>: 
+         <ol>
+          <li>If <var>element</var> is an ASCII case-insensitive match for
+              "<code>self</code>", let result be <var>origin</var>.
+          <li>Otherwise, let <var>result</var> be the result of executing
+              the URL parser on <var>element</var>.
           <li>
-            <a>Enforce</a> the policy <var>policy</var>.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h4 id="is-feature-disabled">Is <var>feature</var> disabled for
-        <var>global</var>?</h4>
-        <p>Given a string (<var>feature</var>) and a global object
-        (<var>global</var>), this algorithm returns "`Disabled`" if
-        <var>feature</var> should be considered disabled, and "`Enabled`"
-        otherwise.</p>
-        <ol>
-          <li>Let <var>policy</var> be <var>global</var>'s <a>Feature Policy
-          List</a>
-          </li>
-          <li>If <var>policy</var> is empty, return "`Enabled`".</li>
-          <li>For each <var>directive</var> in <var>policy</var>:
-            <ol>
-              <li>If <var>directive</var>'s <a>disable</a> contains
-              <var>feature</var>:
-                <ol>
-                  <li>Return "`Disabled`".</li>
-                </ol>
-              </li>
-            </ol>
-          </li>
-          <li>Return "`Enabled`".</li>
-        </ol>
-      </section>
+           If <var>result</var> is not failure: 
+           <ol>
+            <li>Let <var>target</var> be the origin of <var>result</var>.
+            <li>If <var>target</var> is not an opaque origin, append <var>target</var> to <var>allowlist</var>.
+           </ol>
+         </ol>
+        <li>Insert <var>allowlist</var> into <var>directive</var> as the
+          value for the key <var>feature</var>.
+       </ol>
+      <li>Return <var>directive</var>
+     </ol>
     </section>
     <section>
-      <h2>Integration with Fetch</h2>
-      <section>
-        <h2>Set request policy</h2>
-        <p>This monkey patches [fetching algorithm], by inserting the following
-        steps after current step #4:</p>
-        <ol>
-          <li>If [request]'s [client] is not <var>null</var> and has a
-          non-empty <a>feature policy list</a>, run the following steps:
-            <ol>
-              <li>Let <var>policy</var> be the [current global object]'s
-              <a>feature policy list</a>.
-              </li>
-              <li>Let <var>serialized feature policy</var> be the result of
-              executing the [sender requirements] algorithm on
-              <var>policy</var>, as defined in section 3 of [[!HTTP-JFV]].</li>
-              <li>[Append](header-append) <var>Feature-Policy/serialized
-              feature policy</var> to request's [header list].</li>
-            </ol>
-          </li>
-        </ol>
-      </section>
+     <h3 class="heading settled" data-level="8.4" id="merge-directive-with-declared-policy"><span class="secno">8.4. </span><span class="content">Merge directive with declared
+    policy</span><a class="self-link" href="#merge-directive-with-declared-policy"></a></h3>
+     <p>Given a policy direcive (<var>directive</var>) and a declared policy
+    (<var>policy</var>), this algorithm will modify <var>policy</var> to
+    account for the new directive.</p>
+     <ol>
+      <li>
+       For each <var>feature</var> and associated <var>allowlist</var> in <var>directive</var>: 
+       <ol>
+        <li>If <var>policy</var> does not contain an allowlist for <var>feature</var>, then add <var>allowlist</var> to <var>policy</var> as the allowlist for <var>feature</var>.
+       </ol>
+     </ol>
     </section>
     <section>
-      <h2>Integration with XMLHttpRequest</h2>
-      <p>The `open() method` calls into the <a href="#is-feature-disabled"></a>
-      algorithm to determine whether or not to throw, as follows:</p>
-      <ol>
-        <li>Add the following step after the current step 3:
-          <ol>
-            <li>If <var>async</var> is <var>false</var> and the <a href=
-            "#is-feature-disabled"></a> algorithm returns "`Disabled`" when
-            executed upon "`sync-xhr`" and the document's global object, throw
-            "`InvalidAccessError`" exception.
-            </li>
-          </ol>
-        </li>
-      </ol>
+     <h3 class="heading settled" data-level="8.5" id="process-feature-policy-attributes"><span class="secno">8.5. </span><span class="content">Process feature policy
+    attributes</span><a class="self-link" href="#process-feature-policy-attributes"></a></h3>
+     <p>Given an element <var>element</var>, this algorithm returns a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-9">declared feature policy</a>, which may be empty.</p>
+     <ol>
+      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-5">policy directive</a>. 
+      <li>Let <var>valid-features</var> be the result of running <a href="#parse-allow-attribute">Parse allow attribute</a> on the value of <var>element</var>’s <code>allow</code> attribute. 
+      <li>
+       For each <var>feature</var> in <var>valid-features</var>: 
+       <ol>
+        <li>
+         If <var>policy</var> does not contain an allowlist for <var>feature</var>: 
+         <ol>
+          <li>Construct a new declaration for <var>feature</var>, whose
+              allowlist is <var>origin</var>.
+          <li>Add <var>declaration</var> to <var>policy</var>.
+         </ol>
+       </ol>
+      <li>
+       If <var>element</var> is an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a></code> element: 
+       <ol>
+        <li>
+         If <var>element</var>’s <code>allowfullscreen</code> attribute is
+          specified, and <var>policy</var> does not contain an allowlist for <a data-link-type="dfn" href="#fullscreen" id="ref-for-fullscreen-1">fullscreen</a>, 
+         <ol>
+          <li>Construct a new declaration for <a data-link-type="dfn" href="#fullscreen" id="ref-for-fullscreen-2">fullscreen</a>, whose
+              allowlist matches all origins. 
+          <li>Add <var>declaration</var> to <var>policy</var>.
+         </ol>
+        <li>
+         If <var>element</var>’s <code>allowpaymentrequest</code> attribute is specified, and <var>policy</var> does not contain an
+          allowlist for <a data-link-type="dfn" href="#payment" id="ref-for-payment-1">payment</a>, 
+         <ol>
+          <li>Construct a new declaration for <a data-link-type="dfn" href="#payment" id="ref-for-payment-2">payment</a>, whose
+              allowlist matches all origins. 
+          <li>Add <var>declaration</var> to <var>policy</var>.
+         </ol>
+       </ol>
+      <li>Return <var>policy</var>.
+     </ol>
     </section>
     <section>
-      <h2>Integration with WebIDL</h2>
-      <p>This section defines an extended attribute whose presence affects only
-      the ECMAScript binding.</p>
-      <section>
-        <h2>[Feature]</h2>
-        <p>If the <dfn>[Feature]</dfn> [extended attribute] appears on an
-        interface, partial interface, or an individual interface member, it
-        indicates that the interface or interface member is subject to
-        <a>feature policy</a> associated with the ECMAScript global
-        environment's global object.</p>
-        <p>The <a>[Feature]</a> [extended attribute] must [take an identifier],
-        which must be a [global name].</p>
-        <p>Whether a construct that the <a>[Feature]</a> [extended attribute]
-        can be specified on is <dfn>enabled by feature policy for global</dfn>
-        is defined as follows:</p>
-        <ol>
-          <li>If the <a>[Feature]</a> [extended attribute] is specified on the
-          construct, then it is <a>enabled by feature policy for global</a> if
-          the "<a href="#is-feature-disabled">is feature disabled for
-          global?</a>" algorithm returns "`Enabled`" when executed upon the
-          extended attribute's argument and the ECMAScript global environment's
-          global object.
-          </li>
-          <li>Otherwise, if the <a>[Feature]</a> [extended attribute] does not
-          appear on a construct, then it is <a>enabled by feature policy for
-          global</a>, depending on the type of construct:
-            <ol>
-              <li>**Interface**: the interface or dictionary is implicity
-              "`Enabled`" by feature policy.</li>
-              <li>**Partial interface**: the partial interface is <a>enabled by
-              feature policy for global</a> if and only if the original
-              interface definition is.
-              </li>
-              <li>**Interface member**: the interface member is <a>enabled by
-              feature policy for global</a> if and only if the interface or
-              partial interface the member is declared on is.
-              </li>
-            </ol>
-          </li>
-        </ol>
-        <p class="note">Whether a construct is <a>enabled by feature policy for
-        global</a> influences whether it is [exposed] in a given ECMAScript
-        global environment.</p>
-      </section>
+     <h3 class="heading settled" data-level="8.6" id="parse-allow-attribute"><span class="secno">8.6. </span><span class="content">Parse allow attribute</span><a class="self-link" href="#parse-allow-attribute"></a></h3>
+     <p>Given a <var>list</var>, this algorithm returns a list of <a data-link-type="dfn">feature
+    name keywords</a>, which may be empty.</p>
+     <ol>
+      <li>Let <var>valid-features</var> be an empty list.
+      <li>If <var>list</var> is <code>null</code> or empty, return <var>valid-features</var>.
+      <li>
+       For each <var>item</var> in <var>list</var>: 
+       <ol>
+        <li>Convert <var>item</var> to ASCII-lowercase.
+        <li>
+         If <var>item</var> matches a defined <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-3">feature name</a> which is
+          not present in <var>valid-features</var>, 
+         <ol>
+          <li>Append <var>item</var> to <var>valid-features</var>.
+         </ol>
+       </ol>
+      <li>Return <var>valid-features</var>.
+     </ol>
     </section>
-  </section>
-  <section>
-    <h2>IANA Considerations</h2>
+    <section>
+     <h3 class="heading settled" data-level="8.7" id="initialize-for-global"><span class="secno">8.7. </span><span class="content">Initialize <var>global</var>’s Feature
+    Policy from <var>response</var></span><a class="self-link" href="#initialize-for-global"></a></h3>
+     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a> (<var>response</var>) and a global object
+    (<var>global</var>), this algorithm populates <var>global</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-8">Feature Policy</a></p>
+     <ol>
+      <li>Let <var>inherited policies</var> be a new ordered map.
+      <li>Let <var>declared policies</var> be a new ordered map.
+      <li>
+       For each <var>feature</var> supported, 
+       <ol>
+        <li>Let <var>isInherited</var> be the result of running <a href="#define-inherited-policy">§8.8 Define an inherited policy for
+    feature</a> on <var>feature</var> and <var>global</var>. 
+        <li>Set <var>inherited policies</var>[<var>feature</var>] to <var>isInherited</var>.
+       </ol>
+      <li>Let <var>d</var> be the result of executing <a href="#process-response-policy">§8.1 Process response policy</a> on <var>response</var> and <var>global</var>. 
+      <li>
+       For each <var>directive</var> in <var>d</var>: 
+       <ol>
+        <li>If <var>inherited policies</var>[ in <var>inherited policies</var> for <var>directive</var>’s feature is true, then append <var>d</var> to <var>declared policies</var>
+       </ol>
+      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-9">feature policy</a>, with inherited
+      policy set <var>inherited policies</var> and declared policy set <var>declared policies</var>. 
+      <li> <a data-link-type="dfn" href="#enforce" id="ref-for-enforce-2">Enforce</a> the policy <var>policy</var>. 
+     </ol>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="8.8" id="define-inherited-policy"><span class="secno">8.8. </span><span class="content">Define an inherited policy for <var>feature</var></span><a class="self-link" href="#define-inherited-policy"></a></h3>
+     <p>Given a string (<var>feature</var>) and a browsing context
+    (<var>context</var>), this algorithm returns the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-3">inherited policy</a> for that feature.</p>
+     <ol>
+      <li>
+       If <var>context</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>: 
+       <ol>
+        <li>Let <var>parent</var> be <var>context</var>’s parent browsing
+          context’s active document.
+        <li>Let <var>origin</var> be <var>parent</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a>
+        <li>Let <var>container policy</var> be the result of running <a href="#process-feature-policy-attributes">§8.5 Process feature policy
+    attributes</a> on <var>context</var>’s browsing context container. 
+        <li>
+         If <var>feature</var> is a key in <var>container policy</var>: 
+         <ol>
+          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-12">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches-1">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-4">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
+          <li>Otherwise return Disabled.
+         </ol>
+        <li>Otherwise, if feature is allowed by <var>parent</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-10">feature policy</a> for <var>origin</var>, return Enabled. 
+        <li>Otherwise, return Disabled.
+       </ol>
+      <li>Otherwise, return Enabled.
+     </ol>
+    </section>
+    <section>
+     <h3 class="heading settled" data-level="8.9" id="is-feature-enabled"><span class="secno">8.9. </span><span class="content">Is <var>feature</var> enabled in <var>global</var> for <var>origin</var>?</span><a class="self-link" href="#is-feature-enabled"></a></h3>
+     <p>Given a string (<var>feature</var>) and a global object
+    (<var>global</var>), and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> (<var>origin</var>), this algorithm
+    returns "<code>Disabled</code>" if <var>feature</var> should be considered
+    disabled, and "<code>Enabled</code>" otherwise.</p>
+     <ol>
+      <li>Let <var>policy</var> be <var>global</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-11">Feature Policy</a> 
+      <li>If <var>policy</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-5">inherited policy</a> for <var>feature</var> is Disabled, return "<code>Disabled</code>".
+      <li>
+       If <var>feature</var> is present in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-10">declared
+      policy</a>: 
+       <ol>
+        <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-13">allowlist</a> for <var>feature</var> in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-11">declared policy</a> <a data-link-type="dfn" href="#matches" id="ref-for-matches-2">matches</a> <var>origin</var>, then return "<code>Enabled</code>". 
+        <li>Otherwise return "<code>Disabled</code>".
+       </ol>
+      <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-4">default allowlist</a> is <code>["*"]</code>, return "<code>Enabled</code>". 
+      <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-5">default allowlist</a> is <code>["self"]</code>, and <var>origin</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">same origin-domain</a> with <var>global</var>’s active document’s origin, return
+      "<code>Enabled</code>". 
+      <li>Return "<code>Disabled</code>".
+     </ol>
+    </section>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="9" id="iana-considerations"><span class="secno">9. </span><span class="content">IANA Considerations</span><a class="self-link" href="#iana-considerations"></a></h2>
     <p>The permanent message header field registry should be updated with the
-    following registration [[!RFC3864]]:</p>
+  following registration <a data-link-type="biblio" href="#biblio-rfc3864">[RFC3864]</a>:</p>
     <dl>
-      <dt>Header field name</dt>
-      <dd>Feature-Policy</dd>
-      <dt>Applicable protocol</dt>
-      <dd>http</dd>
-      <dt>Status</dt>
-      <dd>standard</dd>
-      <dt>Author/Change controller</dt>
-      <dd>W3C</dd>
-      <dt>Specification document</dt>
-      <dd>
-        <a href="">Feature Policy API</a>
-      </dd>
+     <dt>Header field name
+     <dd>Feature-Policy
+     <dt>Applicable protocol
+     <dd>http
+     <dt>Status
+     <dd>standard
+     <dt>Author/Change controller
+     <dd>W3C
+     <dt>Specification document
+     <dd> <a href="">Feature Policy API</a> 
     </dl>
-  </section>
-  <section id="privacy" class="informative">
-    <h2>Privacy and Security</h2>
-    <p class="issue">TODO</p>
-  </section>
-</body>
-</html>
+   </section>
+   <section class="informative" id="privacy">
+    <h2 class="heading settled" data-level="10" id="privacy-and-security"><span class="secno">10. </span><span class="content">Privacy and Security</span><a class="self-link" href="#privacy-and-security"></a></h2>
+    <p class="issue" id="issue-b7b1e314"><a class="self-link" href="#issue-b7b1e314"></a>TODO</p>
+   </section>
+   <section class="appendix">
+    <h2 class="heading settled" id="defined-features"><span class="content">Appendix A: Features</span><a class="self-link" href="#defined-features"></a></h2>
+    <p>This appendix is a reference to currently-defined valid <a data-link-type="dfn" href="#feature" id="ref-for-feature-8">features</a>, their <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-4">feature name</a> keywords, and their effect
+  effect when applied via a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-6">directive</a> as part
+  of a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-12">feature policy</a>. This reference is non-normative; the actual
+  definitions are given in subsections below.</p>
+    <div class="issue" id="issue-e7336d80"><a class="self-link" href="#issue-e7336d80"></a> As soon as possible, move the definitions to their respective controlling
+    specifications, and link to those specifications from this one. This spec
+    shouldn’t be required to enumerate every feature. </div>
+    <table>
+     <thead>
+      <tr>
+       <th>Feature name
+       <th> <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-6">Default allowlist</a> 
+       <th>Brief description
+     <tbody>
+      <tr>
+       <td> <a data-link-type="dfn" href="#camera" id="ref-for-camera-2">camera</a> 
+       <td><code>self</code>
+       <td>Controls access to video input devices.
+      <tr>
+       <td> <a data-link-type="dfn" href="#eme" id="ref-for-eme-1">eme</a> 
+       <td><code>self</code>
+       <td>Controls whether <code class="idl"><a data-link-type="idl">requestMediaKeySystemAccess()</a></code> is allowed.
+      <tr>
+       <td> <a data-link-type="dfn" href="#fullscreen" id="ref-for-fullscreen-3">fullscreen</a> 
+       <td><code>self</code>
+       <td>Controls whether <code class="idl"><a data-link-type="idl">requestFullscreen()</a></code> is allowed.
+      <tr>
+       <td> <a data-link-type="dfn" href="#geolocation" id="ref-for-geolocation-5">geolocation</a> 
+       <td><code>self</code>
+       <td>Controls access to <a data-link-type="dfn">Geolocation interface</a>.
+      <tr>
+       <td> <a data-link-type="dfn" href="#microphone" id="ref-for-microphone-2">microphone</a> 
+       <td><code>self</code>
+       <td>Controls access to audio input devices.
+      <tr>
+       <td> <a data-link-type="dfn" href="#midi" id="ref-for-midi-1">midi</a> 
+       <td><code>self</code>
+       <td>Controls access to <code class="idl"><a data-link-type="idl">requestMIDIAccess()</a></code> method.
+      <tr>
+       <td> <a data-link-type="dfn" href="#payment" id="ref-for-payment-3">payment</a> 
+       <td><code>self</code>
+       <td>Controls access to <a data-link-type="dfn">PaymentRequest interface</a>.
+      <tr>
+       <td> <a data-link-type="dfn" href="#speaker" id="ref-for-speaker-1">speaker</a> 
+       <td><code>self</code>
+       <td>Controls access to audio output devices.
+      <tr>
+       <td> <a data-link-type="dfn" href="#vibrate" id="ref-for-vibrate-2">vibrate</a> 
+       <td><code>self</code>
+       <td>Controls access to <code class="idl"><a data-link-type="idl">vibrate()</a></code> method.
+    </table>
+    <section>
+     <h3 class="heading settled" id="feature-definitions"><span class="content">Feature Definitions</span><a class="self-link" href="#feature-definitions"></a></h3>
+     <section>
+      <h4 class="heading settled" id="camera-feature"><span class="content">camera</span><a class="self-link" href="#camera-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="camera">camera</dfn> feature controls access to video input devices
+      requested through the <a data-link-type="dfn">NavigatorUserMedia interface</a> (<a data-link-type="biblio" href="#biblio-mediacapture-api">[MEDIACAPTURE-API]</a>).</p>
+      <p>If disabled in a document, then calls to getUserMedia() MUST NOT grant
+      access to video input devices in that document.</p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-5">feature name</a> for <a data-link-type="dfn" href="#camera" id="ref-for-camera-3">camera</a> is "<code>camera</code>"</p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-7">default allowlist</a> for <a data-link-type="dfn" href="#camera" id="ref-for-camera-4">camera</a> is <code>["self"]</code>.</p>
+     </section>
+     <section>
+      <h4 class="heading settled" id="eme-feature"><span class="content">eme</span><a class="self-link" href="#eme-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="eme">eme</dfn> keyword controls whether encrypted media extensions <a data-link-type="biblio" href="#biblio-encrypted-media">[encrypted-media]</a> are available.</p>
+      <p>If disabled in a document, the promise returned by <code class="idl"><a data-link-type="idl">requestMediaKeySystemAccess()</a></code> must reject with a NotSupportedError. </p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-6">feature name</a> for <a data-link-type="dfn" href="#eme" id="ref-for-eme-2">eme</a> is "<code>eme</code>"</p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-8">default allowlist</a> for <a data-link-type="dfn" href="#eme" id="ref-for-eme-3">eme</a> is <code>["self"]</code>.</p>
+     </section>
+     <section>
+      <h4 class="heading settled" id="fullscreen-feature"><span class="content">fullscreen</span><a class="self-link" href="#fullscreen-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fullscreen">fullscreen</dfn> keyword controls whether the <code class="idl"><a data-link-type="idl">requestFullscreen()</a></code> method (<a data-link-type="biblio" href="#biblio-whatwg-fullscreen">[WHATWG-FULLSCREEN]</a>) is allowed to
+      request fullscreen.</p>
+      <p>If disabled in any document, the document will not be allowed to use
+      fullscreen. If enabled, the document will be allowed to use
+      fullscreen.</p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-7">feature name</a> for <a data-link-type="dfn" href="#fullscreen" id="ref-for-fullscreen-4">fullscreen</a> is
+      "<code>fullscreen</code>"</p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-9">default allowlist</a> for <a data-link-type="dfn" href="#fullscreen" id="ref-for-fullscreen-5">fullscreen</a> is <code>["self"]</code>.</p>
+     </section>
+     <section>
+      <h4 class="heading settled" id="geolocation-feature"><span class="content">geolocation</span><a class="self-link" href="#geolocation-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="geolocation">geolocation</dfn> keyword controls whether the current
+      document is alowed to use the <a data-link-type="dfn">Geolocation interface</a> (<a data-link-type="biblio" href="#biblio-geolocation-api">[GEOLOCATION-API]</a>).</p>
+      <p>If disabled in any document, calls to both getCurrentPosition and
+      watchPosition must result in the error callback being invoked with
+      PERMISSION_DENIED.</p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-8">feature name</a> for <a data-link-type="dfn" href="#geolocation" id="ref-for-geolocation-6">geolocation</a> is
+      "<code>geolocation</code>"</p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-10">default allowlist</a> for <a data-link-type="dfn" href="#geolocation" id="ref-for-geolocation-7">geolocation</a> is <code>["self"]</code>.</p>
+     </section>
+     <section>
+      <h4 class="heading settled" id="microphone-feature"><span class="content">microphone</span><a class="self-link" href="#microphone-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="microphone">microphone</dfn> feature controls access to audio input
+      devices requested through the <a data-link-type="dfn">NavigatorUserMedia interface</a> (<a data-link-type="biblio" href="#biblio-mediacapture-api">[MEDIACAPTURE-API]</a>).</p>
+      <p>If disabled in a document, then calls to getUserMedia() MUST NOT grant
+      access to audio input devices in that document.</p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-9">feature name</a> for <a data-link-type="dfn" href="#microphone" id="ref-for-microphone-3">microphone</a> is "<code>microphone</code>" </p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-11">default allowlist</a> for <a data-link-type="dfn" href="#microphone" id="ref-for-microphone-4">microphone</a> is <code>["self"]</code>.</p>
+     </section>
+     <section>
+      <h4 class="heading settled" id="midi-feature"><span class="content">midi</span><a class="self-link" href="#midi-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="midi">midi</dfn> keyword controls whether the current document is
+      allowed to use the <code class="idl"><a data-link-type="idl">requestMIDIAccess()</a></code> method (<a data-link-type="biblio" href="#biblio-webmidi">[WEBMIDI]</a>).</p>
+      <p>If disabled in a document, the promise returned by requestMIDIAccess
+      must reject with a DOMException parameter.</p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-10">feature name</a> for <a data-link-type="dfn" href="#midi" id="ref-for-midi-2">midi</a> is "<code>midi</code>" </p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-12">default allowlist</a> for <a data-link-type="dfn" href="#midi" id="ref-for-midi-3">midi</a> is <code>["self"]</code>.</p>
+     </section>
+     <section>
+      <h4 class="heading settled" id="payment-feature"><span class="content">payment</span><a class="self-link" href="#payment-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="payment">payment</dfn> feature controls whether the current document
+      is allowed to use the <a data-link-type="dfn">PaymentRequest interface</a> (<a data-link-type="biblio" href="#biblio-payment-request">[PAYMENT-REQUEST]</a>).</p>
+      <p>If disabled in a document, then calls to the PaymentRequest constuctor
+      MUST throw a SecurityError.</p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-11">feature name</a> for payment is "<code>payment</code>"</p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-13">default allowlist</a> for <a data-link-type="dfn" href="#payment" id="ref-for-payment-4">payment</a> is <code>["self"]</code>.</p>
+     </section>
+     <section>
+      <h4 class="heading settled" id="speaker-feature"><span class="content">speaker</span><a class="self-link" href="#speaker-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="speaker">speaker</dfn> feature controls access to audio output devices
+      requested through the <a data-link-type="dfn">NavigatorUserMedia interface</a> (<a data-link-type="biblio" href="#biblio-audio-output">[audio-output]</a>).</p>
+      <p>If disabled in a document, then calls to getUserMedia() MUST NOT grant
+      access to audio output devices in that document.</p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-12">feature name</a> for <a data-link-type="dfn" href="#speaker" id="ref-for-speaker-2">speaker</a> is "<code>speaker</code>" </p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-14">default allowlist</a> for <a data-link-type="dfn" href="#speaker" id="ref-for-speaker-3">speaker</a> is <code>["self"]</code>.</p>
+     </section>
+     <section>
+      <h4 class="heading settled" id="vibrate-feature"><span class="content">vibrate</span><a class="self-link" href="#vibrate-feature"></a></h4>
+      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="vibrate">vibrate</dfn> feature controls whether the <code class="idl"><a data-link-type="idl">vibrate()</a></code> method (<a data-link-type="biblio" href="#biblio-vibration">[VIBRATION]</a>) is allowed to cause device vibration.</p>
+      <p>If disabled in a document, then calls to the <code class="idl"><a data-link-type="idl">vibrate()</a></code> method
+      should silently do nothing. If enabled, the browser may allow the device
+      to vibrate.</p>
+      <p>The <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-13">feature name</a> for <a data-link-type="dfn" href="#vibrate" id="ref-for-vibrate-3">vibrate</a> is "<code>vibrate</code>" </p>
+      <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-15">default allowlist</a> for <a data-link-type="dfn" href="#vibrate" id="ref-for-vibrate-4">vibrate</a> is <code>["self"]</code>.</p>
+     </section>
+    </section>
+   </section>
+  </main>
+  <div data-fill-with="conformance">
+   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
+   <p> Conformance requirements are expressed with a combination of descriptive assertions and RFC 2119 terminology.
+            The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+            in the normative parts of this document
+            are to be interpreted as described in RFC 2119.
+            However, for readability,
+            these words do not appear in all uppercase letters in this specification. </p>
+   <p> All of the text of this specification is normative
+            except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+   <p> Examples in this specification are introduced with the words “for example”
+            or are set apart from the normative text with <code>class="example"</code>, like this: </p>
+   <div class="example" id="example-ae2b6bc0"><a class="self-link" href="#example-ae2b6bc0"></a> This is an example of an informative example. </div>
+   <p> Informative notes begin with the word “Note”
+            and are set apart from the normative text with <code>class="note"</code>, like this: </p>
+   <p class="note" role="note"> Note, this is an informative note. </p>
+  </div>
+<script>
+(function() {
+  "use strict";
+  var collapseSidebarText = '<span aria-hidden="true">←</span> '
+                          + '<span>Collapse Sidebar</span>';
+  var expandSidebarText   = '<span aria-hidden="true">→</span> '
+                          + '<span>Pop Out Sidebar</span>';
+  var tocJumpText         = '<span aria-hidden="true">↑</span> '
+                          + '<span>Jump to Table of Contents</span>';
 
-<!-- spec references. preserve before running tidy! -->
-[sandbox attribute]: https://html.spec.whatwg.org/multipage/the-iframe-element.html#attr-iframe-sandbox
-[sandbox directive]: https://www.w3.org/TR/2014/WD-CSP11-20140211/#sandbox
-[window]: https://www.w3.org/TR/html5/browsers.html#dom-window
-[workerglobalscope]: https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope
-[response]: https://fetch.spec.whatwg.org/#concept-response
-[request]: https://fetch.spec.whatwg.org/#concept-request
-[HTTPS state]: https://fetch.spec.whatwg.org/#concept-response-https-state
-[origin]: https://url.spec.whatwg.org/#concept-url-origin
-[url]: https://fetch.spec.whatwg.org/#concept-response-url
-[potentially trustworthy]: https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
-[header list]: https://fetch.spec.whatwg.org/#concept-response-header-list
-[header]: https://fetch.spec.whatwg.org/#concept-header
-[name]: https://fetch.spec.whatwg.org/#concept-header-name
-[value]: https://fetch.spec.whatwg.org/#concept-header-value
-[xhr-open]: https://xhr.spec.whatwg.org/#the-open()-method
-[docwrite method]: https://html.spec.whatwg.org/#dom-document-write
-[async]: https://html.spec.whatwg.org/#attr-script-async
-[defer]: https://html.spec.whatwg.org/#attr-script-defer
-[prepare a script]: https://html.spec.whatwg.org/#prepare-a-script
-[non-blocking]: https://html.spec.whatwg.org/#non-blocking
-[header-append]: https://fetch.spec.whatwg.org/#concept-header-list-append
-[header-list]: https://fetch.spec.whatwg.org/#concept-request-header-list
-[fetching algorithm]: https://fetch.spec.whatwg.org/#fetching
-[global object]: https://html.spec.whatwg.org/multipage/webappapis.html#global-object
-[current global object]: https://html.spec.whatwg.org/#current-global-object
-[client]: https://fetch.spec.whatwg.org/#concept-request-client
-[sender requirements]: https://greenbytes.de/tech/webdav/draft-ietf-httpbis-jfv-02.html#rfc.section.3
-[non-blocking]: https://html.spec.whatwg.org/#non-blocking
-[URL parser]: https://url.spec.whatwg.org/#concept-url-parser
-[origin-of-url]: https://url.spec.whatwg.org/#concept-url-origin
-[ascii case-insensitive]: https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-case-insensitive
-[document]: https://html.spec.whatwg.org/multipage/dom.html#document
-[meta]: https://html.spec.whatwg.org/#the-meta-element
-[http-equiv]: https://html.spec.whatwg.org/#attr-meta-http-equiv
-[meta-content]: https://html.spec.whatwg.org/#attr-meta-content
-[pragma directives]: https://html.spec.whatwg.org/#attr-meta-http-equiv-content-security-policy
-[extended attribute]: https://heycam.github.io/webidl/#dfn-extended-attribute
-[take an identifier]: https://heycam.github.io/webidl/#dfn-xattr-identifier
-[global name]: https://heycam.github.io/webidl/#dfn-global-name
-[exposed]: https://heycam.github.io/webidl/#dfn-exposed
-[cookie attribute]: https://html.spec.whatwg.org/#dom-document-cookie
-[domain attribute]: https://html.spec.whatwg.org/#dom-document-domain
-[top-level browsing context]: https://html.spec.whatwg.org/#top-level-browsing-context
-[nested browsing context]: https://html.spec.whatwg.org/#nested-browsing-context
-[document.write]: https://html.spec.whatwg.org/#dom-document-write
-[document.writeln]: https://html.spec.whatwg.org/#dom-document-writeln
-[Geolocation interface]: https://www.w3.org/TR/geolocation-API/#geolocation_interface
-[NavigatorUserMedia interface]: https://w3c.github.io/mediacapture-main/#navigatorusermedia
-[RTCPeerConnection interface]: http://w3c.github.io/webrtc-pc/#rtcpeerconnection-interface
-[Notification interface]: https://www.w3.org/TR/notifications/#notification
-[PaymentRequest interface]: https://www.w3.org/TR/payment-request/#paymentrequest-interface
-[PushManager interface]: https://w3c.github.io/push-api/#idl-def-PushManager
-[requestMIDIAccess method]: http://webaudio.github.io/web-midi-api/#requestMIDIAccess
-[vibrate method]: https://w3c.github.io/vibration/#idl-def-navigator-vibrate(vibratepattern)
+  var sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
+  var autoToggle   = function(e){ toggleSidebar(e.matches) };
+  if(sidebarMedia.addListener) {
+    sidebarMedia.addListener(autoToggle);
+  }
+
+  function toggleSidebar(on) {
+    if (on == undefined) {
+      on = !document.body.classList.contains('toc-sidebar');
+    }
+
+    /* Don’t scroll to compensate for the ToC if we’re above it already. */
+    var headY = 0;
+    var head = document.querySelector('.head');
+    if (head) {
+      // terrible approx of "top of ToC"
+      headY += head.offsetTop + head.offsetHeight;
+    }
+    var skipScroll = window.scrollY < headY;
+
+    var toggle = document.getElementById('toc-toggle');
+    var tocNav = document.getElementById('toc');
+    if (on) {
+      var tocHeight = tocNav.offsetHeight;
+      document.body.classList.add('toc-sidebar');
+      document.body.classList.remove('toc-inline');
+      toggle.innerHTML = collapseSidebarText;
+      if (!skipScroll) {
+        window.scrollBy(0, 0 - tocHeight);
+      }
+      tocNav.focus();
+      sidebarMedia.addListener(autoToggle); // auto-collapse when out of room
+    }
+    else {
+      document.body.classList.add('toc-inline');
+      document.body.classList.remove('toc-sidebar');
+      toggle.innerHTML = expandSidebarText;
+      if (!skipScroll) {
+        window.scrollBy(0, tocNav.offsetHeight);
+      }
+      if (toggle.matches(':hover')) {
+        /* Unfocus button when not using keyboard navigation,
+           because I don’t know where else to send the focus. */
+        toggle.blur();
+      }
+    }
+  }
+
+  function createSidebarToggle() {
+    /* Create the sidebar toggle in JS; it shouldn’t exist when JS is off. */
+    var toggle = document.createElement('a');
+      /* This should probably be a button, but appearance isn’t standards-track.*/
+    toggle.id = 'toc-toggle';
+    toggle.class = 'toc-toggle';
+    toggle.href = '#toc';
+    toggle.innerHTML = collapseSidebarText;
+
+    sidebarMedia.addListener(autoToggle);
+    var toggler = function(e) {
+      e.preventDefault();
+      sidebarMedia.removeListener(autoToggle); // persist explicit off states
+      toggleSidebar();
+      return false;
+    }
+    toggle.addEventListener('click', toggler, false);
+
+
+    /* Get <nav id=toc-nav>, or make it if we don’t have one. */
+    var tocNav = document.getElementById('toc-nav');
+    if (!tocNav) {
+      tocNav = document.createElement('p');
+      tocNav.id = 'toc-nav';
+      /* Prepend for better keyboard navigation */
+      document.body.insertBefore(tocNav, document.body.firstChild);
+    }
+    /* While we’re at it, make sure we have a Jump to Toc link. */
+    var tocJump = document.getElementById('toc-jump');
+    if (!tocJump) {
+      tocJump = document.createElement('a');
+      tocJump.id = 'toc-jump';
+      tocJump.href = '#toc';
+      tocJump.innerHTML = tocJumpText;
+      tocNav.appendChild(tocJump);
+    }
+
+    tocNav.appendChild(toggle);
+  }
+
+  var toc = document.getElementById('toc');
+  if (toc) {
+    createSidebarToggle();
+    toggleSidebar(sidebarMedia.matches);
+
+    /* If the sidebar has been manually opened and is currently overlaying the text
+       (window too small for the MQ to add the margin to body),
+       then auto-close the sidebar once you click on something in there. */
+    toc.addEventListener('click', function(e) {
+      if(e.target.tagName.toLowerCase() == "a" && document.body.classList.contains('toc-sidebar') && !sidebarMedia.matches) {
+        toggleSidebar(false);
+      }
+    }, false);
+  }
+  else {
+    console.warn("Can’t find Table of Contents. Please use <nav id='toc'> around the ToC.");
+  }
+
+  /* Wrap tables in case they overflow */
+  var tables = document.querySelectorAll(':not(.overlarge) > table.data, :not(.overlarge) > table.index');
+  var numTables = tables.length;
+  for (var i = 0; i < numTables; i++) {
+    var table = tables[i];
+    var wrapper = document.createElement('div');
+    wrapper.className = 'overlarge';
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  }
+
+})();
+</script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#dom-htmliframeelement-allow">allow</a><span>, in §6.3</span>
+   <li><a href="#allowlist">allowlist</a><span>, in §4.8</span>
+   <li><a href="#allowlist">allowlists</a><span>, in §4.8</span>
+   <li><a href="#camera">camera</a><span>, in §Unnumbered section</span>
+   <li><a href="#container-policy">container policy</a><span>, in §4.6</span>
+   <li><a href="#declared-policy">declared feature policy</a><span>, in §4.4</span>
+   <li><a href="#declared-policy">declared policy</a><span>, in §4.4</span>
+   <li><a href="#default-allowlist">default allowlist</a><span>, in §4.9</span>
+   <li><a href="#default-allowlist">default allowlists</a><span>, in §4.9</span>
+   <li><a href="#eme">eme</a><span>, in §Unnumbered section</span>
+   <li><a href="#enforce">enforce</a><span>, in §7.1</span>
+   <li><a href="#feature">feature</a><span>, in §4.1</span>
+   <li><a href="#feature-name">feature name</a><span>, in §4.1</span>
+   <li><a href="#feature-policy">feature policy</a><span>, in §4.2</span>
+   <li><a href="#feature-policy-aware">feature-policy-aware</a><span>, in §4.4</span>
+   <li><a href="#feature-policy-header">feature-policy-header</a><span>, in §6.1</span>
+   <li><a href="#feature-policy-oblivious">feature-policy-oblivious</a><span>, in §4.4</span>
+   <li><a href="#fullscreen">fullscreen</a><span>, in §Unnumbered section</span>
+   <li><a href="#geolocation">geolocation</a><span>, in §Unnumbered section</span>
+   <li><a href="#header-policy">header policy</a><span>, in §4.5</span>
+   <li><a href="#inherited-policy">inherited policies</a><span>, in §4.3</span>
+   <li><a href="#inherited-policy">inherited policy</a><span>, in §4.3</span>
+   <li><a href="#inherited-policy-set">inherited policy set</a><span>, in §4.3</span>
+   <li><a href="#matches">matches</a><span>, in §4.8</span>
+   <li><a href="#microphone">microphone</a><span>, in §Unnumbered section</span>
+   <li><a href="#midi">midi</a><span>, in §Unnumbered section</span>
+   <li><a href="#payment">payment</a><span>, in §Unnumbered section</span>
+   <li><a href="#policy-directive">policy directive</a><span>, in §4.7</span>
+   <li><a href="#policy-directive">policy directives</a><span>, in §4.7</span>
+   <li><a href="#speaker">speaker</a><span>, in §Unnumbered section</span>
+   <li><a href="#supported-features">supported features</a><span>, in §4.1</span>
+   <li><a href="#vibrate">vibrate</a><span>, in §Unnumbered section</span>
+  </ul>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[CSP3]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/webappsec-csp/#sandbox">sandbox</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WHATWG-DOM]</a> defines the following terms:
+    <ul>
+     <li><a href="https://dom.spec.whatwg.org/#domtokenlist">DOMTokenList</a>
+     <li><a href="https://dom.spec.whatwg.org/#dom-domtokenlist-value">value</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
+    <ul>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-header">header</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-header-name">name</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response-response">response</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-header-value">value</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmliframeelement">HTMLIFrameElement</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#allowed-to-use">allowed to use</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">ascii serialization of an origin</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">content</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-request-header-list">header list</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">http-equiv</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">iframe</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">same origin-domain</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-sandbox">sandbox</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-src">src</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-origin">origin</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://heycam.github.io/webidl/#PutForwards">PutForwards</a>
+     <li><a href="https://heycam.github.io/webidl/#SameObject">SameObject</a>
+    </ul>
+  </ul>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-csp3">[CSP3]
+   <dd>Mike West. <a href="https://w3c.github.io/webappsec-csp/">Content Security Policy Level 3</a>. URL: <a href="https://w3c.github.io/webappsec-csp/">https://w3c.github.io/webappsec-csp/</a>
+   <dt id="biblio-fetch">[FETCH]
+   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-html">[HTML]
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dt id="biblio-rfc2119">[RFC2119]
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc3864">[RFC3864]
+   <dd>G. Klyne; M. Nottingham; J. Mogul. <a href="https://tools.ietf.org/html/rfc3864">Registration Procedures for Message Header Fields</a>. September 2004. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc3864">https://tools.ietf.org/html/rfc3864</a>
+   <dt id="biblio-rfc7159">[RFC7159]
+   <dd>T. Bray, Ed.. <a href="https://tools.ietf.org/html/rfc7159">The JavaScript Object Notation (JSON) Data Interchange Format</a>. March 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7159">https://tools.ietf.org/html/rfc7159</a>
+   <dt id="biblio-webidl">[WebIDL]
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dt id="biblio-whatwg-dom">[WHATWG-DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-whatwg-url">[WHATWG-URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+  </dl>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-audio-output">[AUDIO-OUTPUT]
+   <dd>Justin Uberti; Guido Urdaneta. <a href="https://w3c.github.io/mediacapture-output/">Audio Output Devices API</a>. URL: <a href="https://w3c.github.io/mediacapture-output/">https://w3c.github.io/mediacapture-output/</a>
+   <dt id="biblio-csp2">[CSP2]
+   <dd>Mike West; Adam Barth; Daniel Veditz. <a href="https://w3c.github.io/webappsec-csp/">Content Security Policy Level 2</a>. URL: <a href="https://w3c.github.io/webappsec-csp/">https://w3c.github.io/webappsec-csp/</a>
+   <dt id="biblio-encrypted-media">[ENCRYPTED-MEDIA]
+   <dd>David Dorwin; et al. <a href="https://w3c.github.io/encrypted-media/">Encrypted Media Extensions</a>. URL: <a href="https://w3c.github.io/encrypted-media/">https://w3c.github.io/encrypted-media/</a>
+   <dt id="biblio-geolocation-api">[GEOLOCATION-API]
+   <dd>Andrei Popescu. <a href="http://dev.w3.org/geo/api/spec-source.html">Geolocation API Specification 2nd Edition</a>. URL: <a href="http://dev.w3.org/geo/api/spec-source.html">http://dev.w3.org/geo/api/spec-source.html</a>
+   <dt id="biblio-html5">[HTML5]
+   <dd>Ian Hickson; et al. <a href="https://www.w3.org/html/wg/drafts/html/master/">HTML5</a>. URL: <a href="https://www.w3.org/html/wg/drafts/html/master/">https://www.w3.org/html/wg/drafts/html/master/</a>
+   <dt id="biblio-mediacapture-api">[MEDIACAPTURE-API]
+   <dd>Dzung D Tran; Ilkka Oksanen; Ingmar Kliche. <a href="http://dev.w3.org/2009/dap/camera/Overview-API.html">The Media Capture API</a>. 3 September 2010. ED. URL: <a href="http://dev.w3.org/2009/dap/camera/Overview-API.html">http://dev.w3.org/2009/dap/camera/Overview-API.html</a>
+   <dt id="biblio-payment-request">[PAYMENT-REQUEST]
+   <dd>Adrian Bateman; Zach Koch; Roy McElmurry. <a href="https://w3c.github.io/browser-payment-api/">Payment Request API</a>. URL: <a href="https://w3c.github.io/browser-payment-api/">https://w3c.github.io/browser-payment-api/</a>
+   <dt id="biblio-vibration">[VIBRATION]
+   <dd>Anssi Kostiainen. <a href="https://w3c.github.io/vibration/">Vibration API (Second Edition)</a>. URL: <a href="https://w3c.github.io/vibration/">https://w3c.github.io/vibration/</a>
+   <dt id="biblio-webmidi">[WEBMIDI]
+   <dd>Chris Wilson; Jussi Kalliokoski. <a href="https://webaudio.github.io/web-midi-api/">Web MIDI API</a>. URL: <a href="https://webaudio.github.io/web-midi-api/">https://webaudio.github.io/web-midi-api/</a>
+   <dt id="biblio-whatwg-fullscreen">[WHATWG-FULLSCREEN]
+   <dd>Anne van Kesteren. <a href="https://fullscreen.spec.whatwg.org/">Fullscreen API Standard</a>. Living Standard. URL: <a href="https://fullscreen.spec.whatwg.org/">https://fullscreen.spec.whatwg.org/</a>
+  </dl>
+  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmliframeelement">HTMLIFrameElement</a> {
+    [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#PutForwards">PutForwards</a>=<a class="n idl-code" data-link-type="attribute" href="https://dom.spec.whatwg.org/#dom-domtokenlist-value">value</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#domtokenlist">DOMTokenList</a> <a class="nv" data-readonly="" data-type="DOMTokenList" href="#dom-htmliframeelement-allow">allow</a>;
+};
+</pre>
+  <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue"> TODO: Ensure that inserting this element after scripts can run has no
+      effect. <a href="#issue-7c854c21"> ↵ </a></div>
+   <div class="issue"> Monkey-patching! As soon as we know that this is the direction we wish to
+      pursue, upstream all of this. <a href="#issue-7605d231"> ↵ </a></div>
+   <div class="issue">TODO<a href="#issue-b7b1e314"> ↵ </a></div>
+   <div class="issue"> As soon as possible, move the definitions to their respective controlling
+    specifications, and link to those specifications from this one. This spec
+    shouldn’t be required to enumerate every feature. <a href="#issue-e7336d80"> ↵ </a></div>
+  </div>
+  <aside class="dfn-panel" data-for="feature">
+   <b><a href="#feature">#feature</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-feature-1">4.1. Features</a> <a href="#ref-for-feature-2">(2)</a> <a href="#ref-for-feature-3">(3)</a> <a href="#ref-for-feature-4">(4)</a> <a href="#ref-for-feature-5">(5)</a>
+    <li><a href="#ref-for-feature-6">4.3. Inherited policies</a> <a href="#ref-for-feature-7">(2)</a>
+    <li><a href="#ref-for-feature-8">Appendix A: Features</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="feature-name">
+   <b><a href="#feature-name">#feature-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-feature-name-1">4.7. Policy directives</a> <a href="#ref-for-feature-name-2">(2)</a>
+    <li><a href="#ref-for-feature-name-3">8.6. Parse allow attribute</a>
+    <li><a href="#ref-for-feature-name-4">Appendix A: Features</a>
+    <li><a href="#ref-for-feature-name-5">camera</a>
+    <li><a href="#ref-for-feature-name-6">eme</a>
+    <li><a href="#ref-for-feature-name-7">fullscreen</a>
+    <li><a href="#ref-for-feature-name-8">geolocation</a>
+    <li><a href="#ref-for-feature-name-9">microphone</a>
+    <li><a href="#ref-for-feature-name-10">midi</a>
+    <li><a href="#ref-for-feature-name-11">payment</a>
+    <li><a href="#ref-for-feature-name-12">speaker</a>
+    <li><a href="#ref-for-feature-name-13">vibrate</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="feature-policy">
+   <b><a href="#feature-policy">#feature-policy</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-feature-policy-1">4.1. Features</a>
+    <li><a href="#ref-for-feature-policy-2">4.5. Header policies</a>
+    <li><a href="#ref-for-feature-policy-3">6.1. Feature-Policy HTTP Header
+    Field</a>
+    <li><a href="#ref-for-feature-policy-4">7.1. Integration with HTML</a> <a href="#ref-for-feature-policy-5">(2)</a> <a href="#ref-for-feature-policy-6">(3)</a> <a href="#ref-for-feature-policy-7">(4)</a>
+    <li><a href="#ref-for-feature-policy-8">8.7. Initialize global’s Feature
+    Policy from response</a> <a href="#ref-for-feature-policy-9">(2)</a>
+    <li><a href="#ref-for-feature-policy-10">8.8. Define an inherited policy for
+    feature</a>
+    <li><a href="#ref-for-feature-policy-11">8.9. Is feature enabled in
+    global for origin?</a>
+    <li><a href="#ref-for-feature-policy-12">Appendix A: Features</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="inherited-policy">
+   <b><a href="#inherited-policy">#inherited-policy</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-inherited-policy-1">4.3. Inherited policies</a>
+    <li><a href="#ref-for-inherited-policy-2">4.6. Container policies</a>
+    <li><a href="#ref-for-inherited-policy-3">8.8. Define an inherited policy for
+    feature</a> <a href="#ref-for-inherited-policy-4">(2)</a>
+    <li><a href="#ref-for-inherited-policy-5">8.9. Is feature enabled in
+    global for origin?</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="inherited-policy-set">
+   <b><a href="#inherited-policy-set">#inherited-policy-set</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-inherited-policy-set-1">4.2. Policies</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="declared-policy">
+   <b><a href="#declared-policy">#declared-policy</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-declared-policy-1">4.2. Policies</a>
+    <li><a href="#ref-for-declared-policy-2">4.3. Inherited policies</a>
+    <li><a href="#ref-for-declared-policy-3">4.4. Declared policies</a> <a href="#ref-for-declared-policy-4">(2)</a>
+    <li><a href="#ref-for-declared-policy-5">4.5. Header policies</a>
+    <li><a href="#ref-for-declared-policy-6">6.1. Feature-Policy HTTP Header
+    Field</a>
+    <li><a href="#ref-for-declared-policy-7">8.1. Process response policy</a>
+    <li><a href="#ref-for-declared-policy-8">8.2. Parse header from value and
+    origin</a>
+    <li><a href="#ref-for-declared-policy-9">8.5. Process feature policy
+    attributes</a>
+    <li><a href="#ref-for-declared-policy-10">8.9. Is feature enabled in
+    global for origin?</a> <a href="#ref-for-declared-policy-11">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="feature-policy-aware">
+   <b><a href="#feature-policy-aware">#feature-policy-aware</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-feature-policy-aware-1">4.4. Declared policies</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="header-policy">
+   <b><a href="#header-policy">#header-policy</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-header-policy-1">4.6. Container policies</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="container-policy">
+   <b><a href="#container-policy">#container-policy</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-container-policy-1">4.6. Container policies</a> <a href="#ref-for-container-policy-2">(2)</a> <a href="#ref-for-container-policy-3">(3)</a> <a href="#ref-for-container-policy-4">(4)</a>
+    <li><a href="#ref-for-container-policy-5">6.3. The allow attribute of the
+    iframe element</a>
+    <li><a href="#ref-for-container-policy-6">6.4.1. allowfullscreen</a>
+    <li><a href="#ref-for-container-policy-7">6.4.2. allowpaymentrequest</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="policy-directive">
+   <b><a href="#policy-directive">#policy-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-policy-directive-1">4.1. Features</a>
+    <li><a href="#ref-for-policy-directive-2">4.4. Declared policies</a>
+    <li><a href="#ref-for-policy-directive-3">4.6. Container policies</a>
+    <li><a href="#ref-for-policy-directive-4">8.3. Parse policy directive from
+    value and origin</a>
+    <li><a href="#ref-for-policy-directive-5">8.5. Process feature policy
+    attributes</a>
+    <li><a href="#ref-for-policy-directive-6">Appendix A: Features</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="allowlist">
+   <b><a href="#allowlist">#allowlist</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-allowlist-1">2. Examples</a>
+    <li><a href="#ref-for-allowlist-2">4.7. Policy directives</a>
+    <li><a href="#ref-for-allowlist-3">4.8. Allowlists</a> <a href="#ref-for-allowlist-4">(2)</a>
+    <li><a href="#ref-for-allowlist-5">4.9. Default Allowlists</a>
+    <li><a href="#ref-for-allowlist-6">6.3. The allow attribute of the
+    iframe element</a> <a href="#ref-for-allowlist-7">(2)</a>
+    <li><a href="#ref-for-allowlist-8">6.4.1. allowfullscreen</a>
+    <li><a href="#ref-for-allowlist-9">6.4.2. allowpaymentrequest</a>
+    <li><a href="#ref-for-allowlist-10">8.3. Parse policy directive from
+    value and origin</a> <a href="#ref-for-allowlist-11">(2)</a>
+    <li><a href="#ref-for-allowlist-12">8.8. Define an inherited policy for
+    feature</a>
+    <li><a href="#ref-for-allowlist-13">8.9. Is feature enabled in
+    global for origin?</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="matches">
+   <b><a href="#matches">#matches</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-matches-1">8.8. Define an inherited policy for
+    feature</a>
+    <li><a href="#ref-for-matches-2">8.9. Is feature enabled in
+    global for origin?</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="default-allowlist">
+   <b><a href="#default-allowlist">#default-allowlist</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-default-allowlist-1">4.1. Features</a>
+    <li><a href="#ref-for-default-allowlist-2">4.9. Default Allowlists</a> <a href="#ref-for-default-allowlist-3">(2)</a>
+    <li><a href="#ref-for-default-allowlist-4">8.9. Is feature enabled in
+    global for origin?</a> <a href="#ref-for-default-allowlist-5">(2)</a>
+    <li><a href="#ref-for-default-allowlist-6">Appendix A: Features</a>
+    <li><a href="#ref-for-default-allowlist-7">camera</a>
+    <li><a href="#ref-for-default-allowlist-8">eme</a>
+    <li><a href="#ref-for-default-allowlist-9">fullscreen</a>
+    <li><a href="#ref-for-default-allowlist-10">geolocation</a>
+    <li><a href="#ref-for-default-allowlist-11">microphone</a>
+    <li><a href="#ref-for-default-allowlist-12">midi</a>
+    <li><a href="#ref-for-default-allowlist-13">payment</a>
+    <li><a href="#ref-for-default-allowlist-14">speaker</a>
+    <li><a href="#ref-for-default-allowlist-15">vibrate</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="feature-policy-header">
+   <b><a href="#feature-policy-header">#feature-policy-header</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-feature-policy-header-1">2. Examples</a> <a href="#ref-for-feature-policy-header-2">(2)</a> <a href="#ref-for-feature-policy-header-3">(3)</a> <a href="#ref-for-feature-policy-header-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enforce">
+   <b><a href="#enforce">#enforce</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enforce-1">6.1. Feature-Policy HTTP Header
+    Field</a>
+    <li><a href="#ref-for-enforce-2">8.7. Initialize global’s Feature
+    Policy from response</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="camera">
+   <b><a href="#camera">#camera</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-camera-1">2. Examples</a>
+    <li><a href="#ref-for-camera-2">Appendix A: Features</a>
+    <li><a href="#ref-for-camera-3">camera</a> <a href="#ref-for-camera-4">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="eme">
+   <b><a href="#eme">#eme</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eme-1">Appendix A: Features</a>
+    <li><a href="#ref-for-eme-2">eme</a> <a href="#ref-for-eme-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fullscreen">
+   <b><a href="#fullscreen">#fullscreen</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fullscreen-1">8.5. Process feature policy
+    attributes</a> <a href="#ref-for-fullscreen-2">(2)</a>
+    <li><a href="#ref-for-fullscreen-3">Appendix A: Features</a>
+    <li><a href="#ref-for-fullscreen-4">fullscreen</a> <a href="#ref-for-fullscreen-5">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="geolocation">
+   <b><a href="#geolocation">#geolocation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-geolocation-1">2. Examples</a> <a href="#ref-for-geolocation-2">(2)</a> <a href="#ref-for-geolocation-3">(3)</a> <a href="#ref-for-geolocation-4">(4)</a>
+    <li><a href="#ref-for-geolocation-5">Appendix A: Features</a>
+    <li><a href="#ref-for-geolocation-6">geolocation</a> <a href="#ref-for-geolocation-7">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="microphone">
+   <b><a href="#microphone">#microphone</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-microphone-1">2. Examples</a>
+    <li><a href="#ref-for-microphone-2">Appendix A: Features</a>
+    <li><a href="#ref-for-microphone-3">microphone</a> <a href="#ref-for-microphone-4">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="midi">
+   <b><a href="#midi">#midi</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-midi-1">Appendix A: Features</a>
+    <li><a href="#ref-for-midi-2">midi</a> <a href="#ref-for-midi-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="payment">
+   <b><a href="#payment">#payment</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-payment-1">8.5. Process feature policy
+    attributes</a> <a href="#ref-for-payment-2">(2)</a>
+    <li><a href="#ref-for-payment-3">Appendix A: Features</a>
+    <li><a href="#ref-for-payment-4">payment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="speaker">
+   <b><a href="#speaker">#speaker</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-speaker-1">Appendix A: Features</a>
+    <li><a href="#ref-for-speaker-2">speaker</a> <a href="#ref-for-speaker-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="vibrate">
+   <b><a href="#vibrate">#vibrate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-vibrate-1">2. Examples</a>
+    <li><a href="#ref-for-vibrate-2">Appendix A: Features</a>
+    <li><a href="#ref-for-vibrate-3">vibrate</a> <a href="#ref-for-vibrate-4">(2)</a>
+   </ul>
+  </aside>
+<script>/* script-dfn-panel */
+
+        document.body.addEventListener("click", function(e) {
+            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+            // Find the dfn element or panel, if any, that was clicked on.
+            var el = e.target;
+            var target;
+            var hitALink = false;
+            while(el.parentElement) {
+                if(el.tagName == "A") {
+                    // Clicking on a link in a <dfn> shouldn't summon the panel
+                    hitALink = true;
+                }
+                if(el.classList.contains("dfn-paneled")) {
+                    target = "dfn";
+                    break;
+                }
+                if(el.classList.contains("dfn-panel")) {
+                    target = "dfn-panel";
+                    break;
+                }
+                el = el.parentElement;
+            }
+            if(target != "dfn-panel") {
+                // Turn off any currently "on" or "activated" panels.
+                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+                    el.classList.remove("on");
+                    el.classList.remove("activated");
+                });
+            }
+            if(target == "dfn" && !hitALink) {
+                // open the panel
+                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+                if(dfnPanel) {
+                    console.log(dfnPanel);
+                    dfnPanel.classList.add("on");
+                    var rect = el.getBoundingClientRect();
+                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+                    dfnPanel.style.top = window.scrollY + rect.top + "px";
+                    var panelRect = dfnPanel.getBoundingClientRect();
+                    var panelWidth = panelRect.right - panelRect.left;
+                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                        // Reposition, because the panel is overflowing
+                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+                    }
+                } else {
+                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+                }
+            } else if(target == "dfn-panel") {
+                // Switch it to "activated" state, which pins it.
+                el.classList.add("activated");
+                el.style.left = null;
+                el.style.top = null;
+            }
+
+        });
+        </script>

--- a/index.html
+++ b/index.html
@@ -1425,7 +1425,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-02-22">22 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-02-23">23 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2112,7 +2112,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <p>The "<code>allowfullscreen</code>" iframe attribute controls access to <code class="idl"><a data-link-type="idl">requestFullscreen()</a></code>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>fullscreen</code>", then the
-      "<code>allowfullscreen</code> attribute should have no effect.</p>
+      "<code>allowfullscreen</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
       will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-8">allowlist</a> of ["<code>*</code>"] for the
       "fullscreen" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-6">container policy</a>, when it is
@@ -2129,7 +2129,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       access to <a data-link-type="dfn">Payment interface</a>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>payment</code>", then the
-      "<code>allowpaymentrequest</code> attribute should have no effect.</p>
+      "<code>allowpaymentrequest</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
       iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-9">allowlist</a> of ["<code>*</code>"] for
       the "payment" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-7">container policy</a>, when it is


### PR DESCRIPTION
This is a significant update to the Feature Policy spec; in addition to
rewriting the spec in Bikeshed, this brings it in line with the explainer
document, adds iframe policies, removes explicit references to JFV, moves all
of the features into an appendix, (adding a couple of new features, and removing
references to features that we're not planning on trying to standardize on and
ship in the near future.)