### PR TITLE
Rename potentially ambiguous term "Feature"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -125,7 +125,7 @@ spec:fetch; type:dfn; text:value
   <h2 id="framwork">Framework</h2>
   <section>
     <h3 id="features">Policy-controlled Features</h3>
-    <p>A <dfn data-lt="feature|policy-controlled feature">policy-controlled feature</dfn>
+    <p>A <dfn export data-lt="policy-controlled feature">policy-controlled feature</dfn>
     is an API or behaviour which can be enabled or disabled in a document or web
     worker by referring to it in a <a>feature policy</a>.
     <div class="note">For brevity, policy-controlled features will often be
@@ -139,8 +139,9 @@ spec:fetch; type:dfn; text:value
     is available to top-level documents, and how access to that feature is
     inherited by cross-origin frames.</p>
     <p>A user agent has a set of <dfn>supported features</dfn>, which is the set
-    of <a>features</a> which it allows to be controlled through policies. User
-    agents are not required to support every <a>feature</a>.</p>
+    of <a data-lt="policy-controlled feature">features</a> which it allows to be
+    controlled through policies. User agents are not required to support every
+    <a data-lt="policy-controlled feature">feature</a>.</p>
     <p>The <a>policy-controlled features</a> themselves are not themselves part
     of this framework. A non-normative list of currently-defined features is
     included as an appendix to this specification.
@@ -172,15 +173,17 @@ spec:fetch; type:dfn; text:value
     <a href="#iframe-allow-attribute">allow attributes</a> defined on the
     browsing context container.</p>
     <p>An <dfn data-lt="inherited policy|inherited policies">inherited
-    policy</dfn> declares a <a>feature</a> as Enabled or Disabled.</p>
+    policy</dfn> declares a <a data-lt="policy-controlled feature">feature</a>
+    as Enabled or Disabled.</p>
     <p>An <dfn>inherited policy set</dfn> for a {{Document}} or
     {{WorkerGlobalScope}} is the set of <a>inherited policies</a> for each
-    <a>feature</a> available in that scope.</p>
+    <a data-lt="policy-controlled feature">feature</a> available in that scope.</p>
   </section>
   <section>
     <h3 id="declared-policies">Declared policies</h3>
     <p>A <dfn data-lt="declared policy|declared feature policy">declared
-    policy</dfn> is an ordered map from <a>features</a> to <a>allowlists</a>.
+    policy</dfn> is an ordered map from
+    <a data-lt="policy-controlled feature">features</a> to <a>allowlists</a>.
     </p>
     <p>A {{Document}} or {{WorkerGlobalScope}} is considered
     <dfn>feature-policy-aware</dfn> if it has a <a>declared policy</a> which is
@@ -343,7 +346,8 @@ partial interface HTMLIFrameElement {
     case-insensitive. The allowed values are names of features. Unrecognized
     values must be ignored.</p>
     <p>When not empty, the "<code>allow</code>" attribute will result in adding
-    an <a>allowlist</a> for each recognized <a>feature</a> to the frame's
+    an <a>allowlist</a> for each recognized
+    <a data-lt="policy-controlled feature">feature</a> to the frame's
     <a>container policy</a>, when it is contructed.</p>
     <p>The <a>allowlist</a> will contain a single origin, which is the origin
     of the URL in the iframe's <{iframe/src}> attribute.</p>
@@ -351,9 +355,10 @@ partial interface HTMLIFrameElement {
   <section>
     <h3 id="legacy-attributes">Additional attributes to support legacy
     features</h3>
-    <p>Some <a>features</a> controlled by Feature Policy have existing iframe
-    attributes defined. This specification redefines these attributes to act as
-    declared policies for the iframe element.</p>
+    <p>Some <a data-lt="policy-controlled feature">features</a> controlled by
+    Feature Policy have existing iframe attributes defined. This specification
+    redefines these attributes to act as declared policies for the iframe
+    element.</p>
     <section>
       <h4 id="iframe-allowfullscreen-attribute">allowfullscreen</h4>
       <p>The "<code>allowfullscreen</code>" iframe attribute controls access to

--- a/index.bs
+++ b/index.bs
@@ -124,20 +124,26 @@ spec:fetch; type:dfn; text:value
 <section>
   <h2 id="framwork">Framework</h2>
   <section>
-    <h3 id="features">Features</h3>
-    <p>A <dfn>feature</dfn> controlled by this framework is an API or behaviour
-    which can be enabled or disabled in a document or web worker by referring to
-    it in a <a>feature policy</a>.
-    <p><a>Features</a> have a <dfn>feature name</dfn> keyword, which is a token
-    used in <a>policy directives</a>, and a <a>default allowlist</a>, which
-    defines whether the <a>feature</a> is available to top-level documents, and
-    how access to that feature is inherited by cross-origin frames.</p>
+    <h3 id="features">Policy-controlled Features</h3>
+    <p>A <dfn data-lt="feature|policy-controlled feature">policy-controlled feature</dfn>
+    is an API or behaviour which can be enabled or disabled in a document or web
+    worker by referring to it in a <a>feature policy</a>.
+    <div class="note">For brevity, policy-controlled features will often be
+    referred to in this document simply as "Features". Unless otherwise
+    indicated, the term "feature" refers to <a>policy-controlled features</a>.
+    Other specification, defining such features, should use the longer term to
+    avoid any ambiguity.</div>
+    <p><a>Policy-controlled features</a> have a <dfn>feature name</dfn> keyword,
+    which is a token used in <a>policy directives</a>, and a <a>default
+    allowlist</a>, which defines whether the <a>policy-controlled feature</a>
+    is available to top-level documents, and how access to that feature is
+    inherited by cross-origin frames.</p>
     <p>A user agent has a set of <dfn>supported features</dfn>, which is the set
     of <a>features</a> which it allows to be controlled through policies. User
     agents are not required to support every <a>feature</a>.</p>
-    <p><a>Features</a> themselves are not themselves part of this framework. A
-    non-normative list of currently-defined features is included as an appendix
-    to this specification.
+    <p>The <a>policy-controlled features</a> themselves are not themselves part
+    of this framework. A non-normative list of currently-defined features is
+    included as an appendix to this specification.
   </section>
   <section>
     <h3 id="policies">Policies</h3>
@@ -154,9 +160,10 @@ spec:fetch; type:dfn; text:value
     <h3 id="inherited-policies">Inherited policies</h3>
     <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
-    for each feature. This inherited policy set determines the initial state
-    (enabled or disabled) of each feature, and whether it can be controlled by
-    a <a>declared policy</a> in the document.</p>
+    for each <a>policy-controlled feature</a>. This inherited policy set
+    determines the initial state (enabled or disabled) of each feature, and
+    whether it can be controlled by a <a>declared policy</a> in the document.
+    </p>
     <p>In a {{Document}} in a [=top-level browsing context=], or in a
     {{WorkerGlobalScope}}, the inherited feature set is based on defined
     defaults for each feature.</p>
@@ -234,11 +241,11 @@ spec:fetch; type:dfn; text:value
   </section>
   <section>
     <h3 id="default-allowlists">Default Allowlists</h3>
-    <p>Every feature controlled by policy has a <dfn lt=
+    <p>Every <a>policy-controlled feature</a> has a <dfn lt=
     "default allowlist|default allowlists">default allowlist</dfn>, which is an
     <a>allowlist</a>. The <a>default allowlist</a> controls the origins which
     are allowed to access the feature when used in a top-level document with no
-    declared policy, and also determines whether access to a feature is
+    declared policy, and also determines whether access to the feature is
     automatically delegated to child documents.</p>
     <p>Features are currently defined to have one of these three <a>default
     allowlists</a>:</p>
@@ -336,15 +343,15 @@ partial interface HTMLIFrameElement {
     case-insensitive. The allowed values are names of features. Unrecognized
     values must be ignored.</p>
     <p>When not empty, the "<code>allow</code>" attribute will result in adding
-    an <a>allowlist</a> for each recognized feature to the frame's <a>container
-    policy</a>, when it is contructed.</p>
+    an <a>allowlist</a> for each recognized <a>feature</a> to the frame's
+    <a>container policy</a>, when it is contructed.</p>
     <p>The <a>allowlist</a> will contain a single origin, which is the origin
-    of URL in the iframe's <{iframe/src}> attribute.</p>
+    of the URL in the iframe's <{iframe/src}> attribute.</p>
   </section>
   <section>
     <h3 id="legacy-attributes">Additional attributes to support legacy
     features</h3>
-    <p>Some features controlled by Feature Policy have existing iframe
+    <p>Some <a>features</a> controlled by Feature Policy have existing iframe
     attributes defined. This specification redefines these attributes to act as
     declared policies for the iframe element.</p>
     <section>
@@ -502,9 +509,9 @@ partial interface HTMLIFrameElement {
         <var>value</var>:
         <ol>
           <li>If <var>key</var> is not equal to the name of any recognized
-          feature, then continue.</li>
-          <li>Let <var>feature</var> be the feature named by
-          <var>key</var>.</li>
+          <a>policy-controlled feature</a>, then continue.</li>
+          <li>Let <var>feature</var> be the <a>policy-controlled feature</a>
+	  named by <var>key</var>.</li>
           <li>If <var>targetlist</var> is not an array, then continue.</li>
           <li>Let <var>allowlist</var> be a new <a>allowlist</a>.
           </li>
@@ -755,16 +762,17 @@ partial interface HTMLIFrameElement {
   <p class="issue">TODO</p>
 </section>
 <section class="appendix">
-  <h2 id="defined-features">Appendix A: Features</h2>
-  <p>This appendix is a reference to currently-defined valid <a data-lt=
-  "feature">features</a>, their <a>feature name</a> keywords, and their effect
-  effect when applied via a <a data-lt="policy directive">directive</a> as part
-  of a <a>feature policy</a>. This reference is non-normative; the actual
-  definitions are given in subsections below.</p>
+  <h2 id="defined-features">Appendix A: Policy-Controlled Features</h2>
+  <p>This appendix is a reference to currently-defined valid
+  <a>policy-controlled features</a>, their <a>feature name</a> keywords, and
+  their effect effect when applied via a
+  <a data-lt="policy directive">directive</a> as part of a
+  <a>feature policy</a>. This reference is non-normative; the actual definitions
+  are given in subsections below.</p>
   <div class="issue">
     As soon as possible, move the definitions to their respective controlling
     specifications, and link to those specifications from this one. This spec
-    shouldn't be required to enumerate every feature.
+    shouldn't be required to enumerate every policy-controlled feature.
   </div>
   <table>
     <thead>

--- a/index.html
+++ b/index.html
@@ -1657,21 +1657,21 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <h2 class="heading settled" data-level="4" id="framwork"><span class="secno">4. </span><span class="content">Framework</span><a class="self-link" href="#framwork"></a></h2>
     <section>
      <h3 class="heading settled" data-level="4.1" id="features"><span class="secno">4.1. </span><span class="content">Policy-controlled Features</span><a class="self-link" href="#features"></a></h3>
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="feature|policy-controlled feature" data-noexport="" id="feature">policy-controlled feature</dfn> is an API or behaviour which can be enabled or disabled in a document or web
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-controlled-feature">policy-controlled feature</dfn> is an API or behaviour which can be enabled or disabled in a document or web
     worker by referring to it in a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-1">feature policy</a>. </p>
      <div class="note" role="note">For brevity, policy-controlled features will often be
     referred to in this document simply as "Features". Unless otherwise
-    indicated, the term "feature" refers to <a data-link-type="dfn" href="#feature" id="ref-for-feature-1">policy-controlled features</a>.
+    indicated, the term "feature" refers to <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-1">policy-controlled features</a>.
     Other specification, defining such features, should use the longer term to
     avoid any ambiguity.</div>
-     <p><a data-link-type="dfn" href="#feature" id="ref-for-feature-2">Policy-controlled features</a> have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-name">feature name</dfn> keyword,
+     <p><a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-2">Policy-controlled features</a> have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-name">feature name</dfn> keyword,
     which is a token used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-1">policy directives</a>, and a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-1">default
-    allowlist</a>, which defines whether the <a data-link-type="dfn" href="#feature" id="ref-for-feature-3">policy-controlled feature</a> is available to top-level documents, and how access to that feature is
+    allowlist</a>, which defines whether the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-3">policy-controlled feature</a> is available to top-level documents, and how access to that feature is
     inherited by cross-origin frames.</p>
      <p>A user agent has a set of <dfn data-dfn-type="dfn" data-noexport="" id="supported-features">supported features<a class="self-link" href="#supported-features"></a></dfn>, which is the set
-    of <a data-link-type="dfn" href="#feature" id="ref-for-feature-4">features</a> which it allows to be controlled through policies. User
-    agents are not required to support every <a data-link-type="dfn" href="#feature" id="ref-for-feature-5">feature</a>.</p>
-     <p>The <a data-link-type="dfn" href="#feature" id="ref-for-feature-6">policy-controlled features</a> themselves are not themselves part
+    of <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-4">features</a> which it allows to be
+    controlled through policies. User agents are not required to support every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-5">feature</a>.</p>
+     <p>The <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-6">policy-controlled features</a> themselves are not themselves part
     of this framework. A non-normative list of currently-defined features is
     included as an appendix to this specification. </p>
     </section>
@@ -1688,7 +1688,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="4.3" id="inherited-policies"><span class="secno">4.3. </span><span class="content">Inherited policies</span><a class="self-link" href="#inherited-policies"></a></h3>
      <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
-    for each <a data-link-type="dfn" href="#feature" id="ref-for-feature-7">policy-controlled feature</a>. This inherited policy set
+    for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-7">policy-controlled feature</a>. This inherited policy set
     determines the initial state (enabled or disabled) of each feature, and
     whether it can be controlled by a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-2">declared policy</a> in the document. </p>
      <p>In a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>, or in a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>, the inherited feature set is based on defined
@@ -1697,13 +1697,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     set is based on the parent document’s feature policy, as well as any <a href="#iframe-allow-attribute">allow attributes</a> defined on the
     browsing context container.</p>
      <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="inherited policy|inherited policies" data-noexport="" id="inherited-policy">inherited
-    policy</dfn> declares a <a data-link-type="dfn" href="#feature" id="ref-for-feature-8">feature</a> as Enabled or Disabled.</p>
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inherited-policy-set">inherited policy set</dfn> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is the set of <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-1">inherited policies</a> for each <a data-link-type="dfn" href="#feature" id="ref-for-feature-9">feature</a> available in that scope.</p>
+    policy</dfn> declares a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-8">feature</a> as Enabled or Disabled.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inherited-policy-set">inherited policy set</dfn> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is the set of <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-1">inherited policies</a> for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-9">feature</a> available in that scope.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.4" id="declared-policies"><span class="secno">4.4. </span><span class="content">Declared policies</span><a class="self-link" href="#declared-policies"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="declared policy|declared feature policy" data-noexport="" id="declared-policy">declared
-    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#feature" id="ref-for-feature-10">features</a> to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-2">allowlists</a>. </p>
+    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-10">features</a> to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-2">allowlists</a>. </p>
      <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is considered <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-policy-aware">feature-policy-aware</dfn> if it has a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-3">declared policy</a> which is
     not empty.</p>
      <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is which is not <a data-link-type="dfn" href="#feature-policy-aware" id="ref-for-feature-policy-aware-1">feature-policy-aware</a> is considered <dfn data-dfn-type="dfn" data-noexport="" id="feature-policy-oblivious">feature-policy-oblivious<a class="self-link" href="#feature-policy-oblivious"></a></dfn>.</p>
@@ -1752,7 +1752,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="4.9" id="default-allowlists"><span class="secno">4.9. </span><span class="content">Default Allowlists</span><a class="self-link" href="#default-allowlists"></a></h3>
-     <p>Every <a data-link-type="dfn" href="#feature" id="ref-for-feature-11">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>, which is an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-6">allowlist</a>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-2">default allowlist</a> controls the origins which
+     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-11">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>, which is an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-6">allowlist</a>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-2">default allowlist</a> controls the origins which
     are allowed to access the feature when used in a top-level document with no
     declared policy, and also determines whether access to the feature is
     automatically delegated to child documents.</p>
@@ -2065,16 +2065,17 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     case-insensitive. The allowed values are names of features. Unrecognized
     values must be ignored.</p>
      <p>When not empty, the "<code>allow</code>" attribute will result in adding
-    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-7">allowlist</a> for each recognized <a data-link-type="dfn" href="#feature" id="ref-for-feature-12">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-5">container policy</a>, when it is contructed.</p>
+    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-7">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-12">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-5">container policy</a>, when it is contructed.</p>
      <p>The <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-8">allowlist</a> will contain a single origin, which is the origin
     of the URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-src">src</a></code> attribute.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.3" id="legacy-attributes"><span class="secno">6.3. </span><span class="content">Additional attributes to support legacy
     features</span><a class="self-link" href="#legacy-attributes"></a></h3>
-     <p>Some <a data-link-type="dfn" href="#feature" id="ref-for-feature-13">features</a> controlled by Feature Policy have existing iframe
-    attributes defined. This specification redefines these attributes to act as
-    declared policies for the iframe element.</p>
+     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-13">features</a> controlled by
+    Feature Policy have existing iframe attributes defined. This specification
+    redefines these attributes to act as declared policies for the iframe
+    element.</p>
      <section>
       <h4 class="heading settled" data-level="6.3.1" id="iframe-allowfullscreen-attribute"><span class="secno">6.3.1. </span><span class="content">allowfullscreen</span><a class="self-link" href="#iframe-allowfullscreen-attribute"></a></h4>
       <p>The "<code>allowfullscreen</code>" iframe attribute controls access to <code class="idl"><a data-link-type="idl">requestFullscreen()</a></code>.</p>
@@ -2196,8 +2197,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>
        For each <var>key</var> → <var>targetlist</var> of <var>value</var>: 
        <ol>
-        <li>If <var>key</var> is not equal to the name of any recognized <a data-link-type="dfn" href="#feature" id="ref-for-feature-14">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#feature" id="ref-for-feature-15">policy-controlled feature</a> named by <var>key</var>.
+        <li>If <var>key</var> is not equal to the name of any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-14">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-15">policy-controlled feature</a> named by <var>key</var>.
         <li>If <var>targetlist</var> is not an array, then continue.
         <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-11">allowlist</a>. 
         <li>If <var>targetlist</var> contains the string "<code>*</code>",
@@ -2395,7 +2396,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    </section>
    <section class="appendix">
     <h2 class="heading settled" id="defined-features"><span class="content">Appendix A: Policy-Controlled Features</span><a class="self-link" href="#defined-features"></a></h2>
-    <p>This appendix is a reference to currently-defined valid <a data-link-type="dfn" href="#feature" id="ref-for-feature-16">policy-controlled features</a>, their <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-4">feature name</a> keywords, and
+    <p>This appendix is a reference to currently-defined valid <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-16">policy-controlled features</a>, their <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-4">feature name</a> keywords, and
   their effect effect when applied via a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-9">directive</a> as part of a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-12">feature policy</a>. This reference is non-normative; the actual definitions
   are given in subsections below.</p>
     <div class="issue" id="issue-3f060b31"><a class="self-link" href="#issue-3f060b31"></a> As soon as possible, move the definitions to their respective controlling
@@ -2694,7 +2695,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#default-allowlist">default allowlists</a><span>, in §4.9</span>
    <li><a href="#eme">eme</a><span>, in §Unnumbered section</span>
    <li><a href="#enforce">enforce</a><span>, in §7.1</span>
-   <li><a href="#feature">feature</a><span>, in §4.1</span>
    <li><a href="#feature-name">feature name</a><span>, in §4.1</span>
    <li><a href="#feature-policy">feature policy</a><span>, in §4.2</span>
    <li><a href="#feature-policy-aware">feature-policy-aware</a><span>, in §4.4</span>
@@ -2710,7 +2710,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#microphone">microphone</a><span>, in §Unnumbered section</span>
    <li><a href="#midi">midi</a><span>, in §Unnumbered section</span>
    <li><a href="#payment">payment</a><span>, in §Unnumbered section</span>
-   <li><a href="#feature">policy-controlled feature</a><span>, in §4.1</span>
+   <li><a href="#policy-controlled-feature">policy-controlled feature</a><span>, in §4.1</span>
    <li><a href="#policy-directive">policy directive</a><span>, in §4.7</span>
    <li><a href="#policy-directive-json">policy-directive-json</a><span>, in §5.1</span>
    <li><a href="#policy-directive">policy directives</a><span>, in §4.7</span>
@@ -2828,20 +2828,20 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     specifications, and link to those specifications from this one. This spec
     shouldn’t be required to enumerate every policy-controlled feature. <a href="#issue-3f060b31"> ↵ </a></div>
   </div>
-  <aside class="dfn-panel" data-for="feature">
-   <b><a href="#feature">#feature</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="policy-controlled-feature">
+   <b><a href="#policy-controlled-feature">#policy-controlled-feature</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-feature-1">4.1. Policy-controlled Features</a> <a href="#ref-for-feature-2">(2)</a> <a href="#ref-for-feature-3">(3)</a> <a href="#ref-for-feature-4">(4)</a> <a href="#ref-for-feature-5">(5)</a> <a href="#ref-for-feature-6">(6)</a>
-    <li><a href="#ref-for-feature-7">4.3. Inherited policies</a> <a href="#ref-for-feature-8">(2)</a> <a href="#ref-for-feature-9">(3)</a>
-    <li><a href="#ref-for-feature-10">4.4. Declared policies</a>
-    <li><a href="#ref-for-feature-11">4.9. Default Allowlists</a>
-    <li><a href="#ref-for-feature-12">6.2. The allow attribute of the
+    <li><a href="#ref-for-policy-controlled-feature-1">4.1. Policy-controlled Features</a> <a href="#ref-for-policy-controlled-feature-2">(2)</a> <a href="#ref-for-policy-controlled-feature-3">(3)</a> <a href="#ref-for-policy-controlled-feature-4">(4)</a> <a href="#ref-for-policy-controlled-feature-5">(5)</a> <a href="#ref-for-policy-controlled-feature-6">(6)</a>
+    <li><a href="#ref-for-policy-controlled-feature-7">4.3. Inherited policies</a> <a href="#ref-for-policy-controlled-feature-8">(2)</a> <a href="#ref-for-policy-controlled-feature-9">(3)</a>
+    <li><a href="#ref-for-policy-controlled-feature-10">4.4. Declared policies</a>
+    <li><a href="#ref-for-policy-controlled-feature-11">4.9. Default Allowlists</a>
+    <li><a href="#ref-for-policy-controlled-feature-12">6.2. The allow attribute of the
     iframe element</a>
-    <li><a href="#ref-for-feature-13">6.3. Additional attributes to support legacy
+    <li><a href="#ref-for-policy-controlled-feature-13">6.3. Additional attributes to support legacy
     features</a>
-    <li><a href="#ref-for-feature-14">8.3. Parse policy directive from
-    value and origin</a> <a href="#ref-for-feature-15">(2)</a>
-    <li><a href="#ref-for-feature-16">Appendix A: Policy-Controlled Features</a>
+    <li><a href="#ref-for-policy-controlled-feature-14">8.3. Parse policy directive from
+    value and origin</a> <a href="#ref-for-policy-controlled-feature-15">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature-16">Appendix A: Policy-Controlled Features</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="feature-name">

--- a/index.html
+++ b/index.html
@@ -1425,7 +1425,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-03-03">3 March 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-03-30">30 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1467,7 +1467,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li>
      <a href="#framwork"><span class="secno">4</span> <span class="content">Framework</span></a>
      <ol class="toc">
-      <li><a href="#features"><span class="secno">4.1</span> <span class="content">Features</span></a>
+      <li><a href="#features"><span class="secno">4.1</span> <span class="content">Policy-controlled Features</span></a>
       <li><a href="#policies"><span class="secno">4.2</span> <span class="content">Policies</span></a>
       <li><a href="#inherited-policies"><span class="secno">4.3</span> <span class="content">Inherited policies</span></a>
       <li><a href="#declared-policies"><span class="secno">4.4</span> <span class="content">Declared policies</span></a>
@@ -1520,7 +1520,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#iana-considerations"><span class="secno">9</span> <span class="content">IANA Considerations</span></a>
     <li><a href="#privacy-and-security"><span class="secno">10</span> <span class="content">Privacy and Security</span></a>
     <li>
-     <a href="#defined-features"><span class="secno"></span> <span class="content">Appendix A: Features</span></a>
+     <a href="#defined-features"><span class="secno"></span> <span class="content">Appendix A: Policy-Controlled Features</span></a>
      <ol class="toc">
       <li>
        <a href="#feature-definitions"><span class="secno"></span> <span class="content">Feature Definitions</span></a>
@@ -1656,20 +1656,24 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <section>
     <h2 class="heading settled" data-level="4" id="framwork"><span class="secno">4. </span><span class="content">Framework</span><a class="self-link" href="#framwork"></a></h2>
     <section>
-     <h3 class="heading settled" data-level="4.1" id="features"><span class="secno">4.1. </span><span class="content">Features</span><a class="self-link" href="#features"></a></h3>
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature">feature</dfn> controlled by this framework is an API or behaviour
-    which can be enabled or disabled in a document or web worker by referring to
-    it in a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-1">feature policy</a>. </p>
-     <p><a data-link-type="dfn" href="#feature" id="ref-for-feature-1">Features</a> have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-name">feature name</dfn> keyword, which is a token
-    used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-1">policy directives</a>, and a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-1">default allowlist</a>, which
-    defines whether the <a data-link-type="dfn" href="#feature" id="ref-for-feature-2">feature</a> is available to top-level documents, and
-    how access to that feature is inherited by cross-origin frames.</p>
+     <h3 class="heading settled" data-level="4.1" id="features"><span class="secno">4.1. </span><span class="content">Policy-controlled Features</span><a class="self-link" href="#features"></a></h3>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="feature|policy-controlled feature" data-noexport="" id="feature">policy-controlled feature</dfn> is an API or behaviour which can be enabled or disabled in a document or web
+    worker by referring to it in a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-1">feature policy</a>. </p>
+     <div class="note" role="note">For brevity, policy-controlled features will often be
+    referred to in this document simply as "Features". Unless otherwise
+    indicated, the term "feature" refers to <a data-link-type="dfn" href="#feature" id="ref-for-feature-1">policy-controlled features</a>.
+    Other specification, defining such features, should use the longer term to
+    avoid any ambiguity.</div>
+     <p><a data-link-type="dfn" href="#feature" id="ref-for-feature-2">Policy-controlled features</a> have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-name">feature name</dfn> keyword,
+    which is a token used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-1">policy directives</a>, and a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-1">default
+    allowlist</a>, which defines whether the <a data-link-type="dfn" href="#feature" id="ref-for-feature-3">policy-controlled feature</a> is available to top-level documents, and how access to that feature is
+    inherited by cross-origin frames.</p>
      <p>A user agent has a set of <dfn data-dfn-type="dfn" data-noexport="" id="supported-features">supported features<a class="self-link" href="#supported-features"></a></dfn>, which is the set
-    of <a data-link-type="dfn" href="#feature" id="ref-for-feature-3">features</a> which it allows to be controlled through policies. User
-    agents are not required to support every <a data-link-type="dfn" href="#feature" id="ref-for-feature-4">feature</a>.</p>
-     <p><a data-link-type="dfn" href="#feature" id="ref-for-feature-5">Features</a> themselves are not themselves part of this framework. A
-    non-normative list of currently-defined features is included as an appendix
-    to this specification. </p>
+    of <a data-link-type="dfn" href="#feature" id="ref-for-feature-4">features</a> which it allows to be controlled through policies. User
+    agents are not required to support every <a data-link-type="dfn" href="#feature" id="ref-for-feature-5">feature</a>.</p>
+     <p>The <a data-link-type="dfn" href="#feature" id="ref-for-feature-6">policy-controlled features</a> themselves are not themselves part
+    of this framework. A non-normative list of currently-defined features is
+    included as an appendix to this specification. </p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.2" id="policies"><span class="secno">4.2. </span><span class="content">Policies</span><a class="self-link" href="#policies"></a></h3>
@@ -1684,22 +1688,22 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="4.3" id="inherited-policies"><span class="secno">4.3. </span><span class="content">Inherited policies</span><a class="self-link" href="#inherited-policies"></a></h3>
      <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
-    for each feature. This inherited policy set determines the initial state
-    (enabled or disabled) of each feature, and whether it can be controlled by
-    a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-2">declared policy</a> in the document.</p>
+    for each <a data-link-type="dfn" href="#feature" id="ref-for-feature-7">policy-controlled feature</a>. This inherited policy set
+    determines the initial state (enabled or disabled) of each feature, and
+    whether it can be controlled by a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-2">declared policy</a> in the document. </p>
      <p>In a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>, or in a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>, the inherited feature set is based on defined
     defaults for each feature.</p>
      <p>In a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>, the inherited feature
     set is based on the parent document’s feature policy, as well as any <a href="#iframe-allow-attribute">allow attributes</a> defined on the
     browsing context container.</p>
      <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="inherited policy|inherited policies" data-noexport="" id="inherited-policy">inherited
-    policy</dfn> declares a <a data-link-type="dfn" href="#feature" id="ref-for-feature-6">feature</a> as Enabled or Disabled.</p>
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inherited-policy-set">inherited policy set</dfn> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is the set of <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-1">inherited policies</a> for each <a data-link-type="dfn" href="#feature" id="ref-for-feature-7">feature</a> available in that scope.</p>
+    policy</dfn> declares a <a data-link-type="dfn" href="#feature" id="ref-for-feature-8">feature</a> as Enabled or Disabled.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inherited-policy-set">inherited policy set</dfn> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is the set of <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-1">inherited policies</a> for each <a data-link-type="dfn" href="#feature" id="ref-for-feature-9">feature</a> available in that scope.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.4" id="declared-policies"><span class="secno">4.4. </span><span class="content">Declared policies</span><a class="self-link" href="#declared-policies"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="declared policy|declared feature policy" data-noexport="" id="declared-policy">declared
-    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#feature" id="ref-for-feature-8">features</a> to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-2">allowlists</a>. </p>
+    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#feature" id="ref-for-feature-10">features</a> to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-2">allowlists</a>. </p>
      <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is considered <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-policy-aware">feature-policy-aware</dfn> if it has a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-3">declared policy</a> which is
     not empty.</p>
      <p>A <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> is which is not <a data-link-type="dfn" href="#feature-policy-aware" id="ref-for-feature-policy-aware-1">feature-policy-aware</a> is considered <dfn data-dfn-type="dfn" data-noexport="" id="feature-policy-oblivious">feature-policy-oblivious<a class="self-link" href="#feature-policy-oblivious"></a></dfn>.</p>
@@ -1748,9 +1752,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="4.9" id="default-allowlists"><span class="secno">4.9. </span><span class="content">Default Allowlists</span><a class="self-link" href="#default-allowlists"></a></h3>
-     <p>Every feature controlled by policy has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>, which is an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-6">allowlist</a>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-2">default allowlist</a> controls the origins which
+     <p>Every <a data-link-type="dfn" href="#feature" id="ref-for-feature-11">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>, which is an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-6">allowlist</a>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-2">default allowlist</a> controls the origins which
     are allowed to access the feature when used in a top-level document with no
-    declared policy, and also determines whether access to a feature is
+    declared policy, and also determines whether access to the feature is
     automatically delegated to child documents.</p>
      <p>Features are currently defined to have one of these three <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-3">default
     allowlists</a>:</p>
@@ -2061,15 +2065,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     case-insensitive. The allowed values are names of features. Unrecognized
     values must be ignored.</p>
      <p>When not empty, the "<code>allow</code>" attribute will result in adding
-    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-7">allowlist</a> for each recognized feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-5">container
-    policy</a>, when it is contructed.</p>
+    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-7">allowlist</a> for each recognized <a data-link-type="dfn" href="#feature" id="ref-for-feature-12">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-5">container policy</a>, when it is contructed.</p>
      <p>The <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-8">allowlist</a> will contain a single origin, which is the origin
-    of URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-src">src</a></code> attribute.</p>
+    of the URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-iframe-src">src</a></code> attribute.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.3" id="legacy-attributes"><span class="secno">6.3. </span><span class="content">Additional attributes to support legacy
     features</span><a class="self-link" href="#legacy-attributes"></a></h3>
-     <p>Some features controlled by Feature Policy have existing iframe
+     <p>Some <a data-link-type="dfn" href="#feature" id="ref-for-feature-13">features</a> controlled by Feature Policy have existing iframe
     attributes defined. This specification redefines these attributes to act as
     declared policies for the iframe element.</p>
      <section>
@@ -2193,9 +2196,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>
        For each <var>key</var> → <var>targetlist</var> of <var>value</var>: 
        <ol>
-        <li>If <var>key</var> is not equal to the name of any recognized
-          feature, then continue.
-        <li>Let <var>feature</var> be the feature named by <var>key</var>.
+        <li>If <var>key</var> is not equal to the name of any recognized <a data-link-type="dfn" href="#feature" id="ref-for-feature-14">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#feature" id="ref-for-feature-15">policy-controlled feature</a> named by <var>key</var>.
         <li>If <var>targetlist</var> is not an array, then continue.
         <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-11">allowlist</a>. 
         <li>If <var>targetlist</var> contains the string "<code>*</code>",
@@ -2392,14 +2394,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <p class="issue" id="issue-b7b1e314"><a class="self-link" href="#issue-b7b1e314"></a>TODO</p>
    </section>
    <section class="appendix">
-    <h2 class="heading settled" id="defined-features"><span class="content">Appendix A: Features</span><a class="self-link" href="#defined-features"></a></h2>
-    <p>This appendix is a reference to currently-defined valid <a data-link-type="dfn" href="#feature" id="ref-for-feature-9">features</a>, their <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-4">feature name</a> keywords, and their effect
-  effect when applied via a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-9">directive</a> as part
-  of a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-12">feature policy</a>. This reference is non-normative; the actual
-  definitions are given in subsections below.</p>
-    <div class="issue" id="issue-e7336d80"><a class="self-link" href="#issue-e7336d80"></a> As soon as possible, move the definitions to their respective controlling
+    <h2 class="heading settled" id="defined-features"><span class="content">Appendix A: Policy-Controlled Features</span><a class="self-link" href="#defined-features"></a></h2>
+    <p>This appendix is a reference to currently-defined valid <a data-link-type="dfn" href="#feature" id="ref-for-feature-16">policy-controlled features</a>, their <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-4">feature name</a> keywords, and
+  their effect effect when applied via a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-9">directive</a> as part of a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-12">feature policy</a>. This reference is non-normative; the actual definitions
+  are given in subsections below.</p>
+    <div class="issue" id="issue-3f060b31"><a class="self-link" href="#issue-3f060b31"></a> As soon as possible, move the definitions to their respective controlling
     specifications, and link to those specifications from this one. This spec
-    shouldn’t be required to enumerate every feature. </div>
+    shouldn’t be required to enumerate every policy-controlled feature. </div>
     <table>
      <thead>
       <tr>
@@ -2709,6 +2710,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#microphone">microphone</a><span>, in §Unnumbered section</span>
    <li><a href="#midi">midi</a><span>, in §Unnumbered section</span>
    <li><a href="#payment">payment</a><span>, in §Unnumbered section</span>
+   <li><a href="#feature">policy-controlled feature</a><span>, in §4.1</span>
    <li><a href="#policy-directive">policy directive</a><span>, in §4.7</span>
    <li><a href="#policy-directive-json">policy-directive-json</a><span>, in §5.1</span>
    <li><a href="#policy-directive">policy directives</a><span>, in §4.7</span>
@@ -2824,15 +2826,22 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <div class="issue">TODO<a href="#issue-b7b1e314"> ↵ </a></div>
    <div class="issue"> As soon as possible, move the definitions to their respective controlling
     specifications, and link to those specifications from this one. This spec
-    shouldn’t be required to enumerate every feature. <a href="#issue-e7336d80"> ↵ </a></div>
+    shouldn’t be required to enumerate every policy-controlled feature. <a href="#issue-3f060b31"> ↵ </a></div>
   </div>
   <aside class="dfn-panel" data-for="feature">
    <b><a href="#feature">#feature</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-feature-1">4.1. Features</a> <a href="#ref-for-feature-2">(2)</a> <a href="#ref-for-feature-3">(3)</a> <a href="#ref-for-feature-4">(4)</a> <a href="#ref-for-feature-5">(5)</a>
-    <li><a href="#ref-for-feature-6">4.3. Inherited policies</a> <a href="#ref-for-feature-7">(2)</a>
-    <li><a href="#ref-for-feature-8">4.4. Declared policies</a>
-    <li><a href="#ref-for-feature-9">Appendix A: Features</a>
+    <li><a href="#ref-for-feature-1">4.1. Policy-controlled Features</a> <a href="#ref-for-feature-2">(2)</a> <a href="#ref-for-feature-3">(3)</a> <a href="#ref-for-feature-4">(4)</a> <a href="#ref-for-feature-5">(5)</a> <a href="#ref-for-feature-6">(6)</a>
+    <li><a href="#ref-for-feature-7">4.3. Inherited policies</a> <a href="#ref-for-feature-8">(2)</a> <a href="#ref-for-feature-9">(3)</a>
+    <li><a href="#ref-for-feature-10">4.4. Declared policies</a>
+    <li><a href="#ref-for-feature-11">4.9. Default Allowlists</a>
+    <li><a href="#ref-for-feature-12">6.2. The allow attribute of the
+    iframe element</a>
+    <li><a href="#ref-for-feature-13">6.3. Additional attributes to support legacy
+    features</a>
+    <li><a href="#ref-for-feature-14">8.3. Parse policy directive from
+    value and origin</a> <a href="#ref-for-feature-15">(2)</a>
+    <li><a href="#ref-for-feature-16">Appendix A: Policy-Controlled Features</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="feature-name">
@@ -2840,7 +2849,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-feature-name-1">4.7. Policy directives</a> <a href="#ref-for-feature-name-2">(2)</a>
     <li><a href="#ref-for-feature-name-3">8.6. Parse allow attribute</a>
-    <li><a href="#ref-for-feature-name-4">Appendix A: Features</a>
+    <li><a href="#ref-for-feature-name-4">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-feature-name-5">camera</a>
     <li><a href="#ref-for-feature-name-6">eme</a>
     <li><a href="#ref-for-feature-name-7">fullscreen</a>
@@ -2855,7 +2864,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="feature-policy">
    <b><a href="#feature-policy">#feature-policy</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-feature-policy-1">4.1. Features</a>
+    <li><a href="#ref-for-feature-policy-1">4.1. Policy-controlled Features</a>
     <li><a href="#ref-for-feature-policy-2">4.5. Header policies</a>
     <li><a href="#ref-for-feature-policy-3">6.1. Feature-Policy HTTP Header
     Field</a>
@@ -2866,7 +2875,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     feature</a>
     <li><a href="#ref-for-feature-policy-11">8.9. Is feature enabled in
     global for origin?</a>
-    <li><a href="#ref-for-feature-policy-12">Appendix A: Features</a>
+    <li><a href="#ref-for-feature-policy-12">Appendix A: Policy-Controlled Features</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="inherited-policy">
@@ -2927,7 +2936,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="policy-directive">
    <b><a href="#policy-directive">#policy-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-policy-directive-1">4.1. Features</a>
+    <li><a href="#ref-for-policy-directive-1">4.1. Policy-controlled Features</a>
     <li><a href="#ref-for-policy-directive-2">4.5. Header policies</a>
     <li><a href="#ref-for-policy-directive-3">4.6. Container policies</a>
     <li><a href="#ref-for-policy-directive-4">4.7. Policy directives</a>
@@ -2938,7 +2947,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     value and origin</a>
     <li><a href="#ref-for-policy-directive-8">8.5. Process feature policy
     attributes</a>
-    <li><a href="#ref-for-policy-directive-9">Appendix A: Features</a>
+    <li><a href="#ref-for-policy-directive-9">Appendix A: Policy-Controlled Features</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="allowlist">
@@ -2973,11 +2982,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="default-allowlist">
    <b><a href="#default-allowlist">#default-allowlist</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-default-allowlist-1">4.1. Features</a>
+    <li><a href="#ref-for-default-allowlist-1">4.1. Policy-controlled Features</a>
     <li><a href="#ref-for-default-allowlist-2">4.9. Default Allowlists</a> <a href="#ref-for-default-allowlist-3">(2)</a>
     <li><a href="#ref-for-default-allowlist-4">8.9. Is feature enabled in
     global for origin?</a> <a href="#ref-for-default-allowlist-5">(2)</a>
-    <li><a href="#ref-for-default-allowlist-6">Appendix A: Features</a>
+    <li><a href="#ref-for-default-allowlist-6">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-default-allowlist-7">camera</a>
     <li><a href="#ref-for-default-allowlist-8">eme</a>
     <li><a href="#ref-for-default-allowlist-9">fullscreen</a>
@@ -3015,14 +3024,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#camera">#camera</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-camera-1">2. Examples</a>
-    <li><a href="#ref-for-camera-2">Appendix A: Features</a>
+    <li><a href="#ref-for-camera-2">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-camera-3">camera</a> <a href="#ref-for-camera-4">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="eme">
    <b><a href="#eme">#eme</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-eme-1">Appendix A: Features</a>
+    <li><a href="#ref-for-eme-1">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-eme-2">eme</a> <a href="#ref-for-eme-3">(2)</a>
    </ul>
   </aside>
@@ -3031,7 +3040,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-fullscreen-1">8.5. Process feature policy
     attributes</a> <a href="#ref-for-fullscreen-2">(2)</a>
-    <li><a href="#ref-for-fullscreen-3">Appendix A: Features</a>
+    <li><a href="#ref-for-fullscreen-3">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-fullscreen-4">fullscreen</a> <a href="#ref-for-fullscreen-5">(2)</a>
    </ul>
   </aside>
@@ -3039,7 +3048,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#geolocation">#geolocation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geolocation-1">2. Examples</a> <a href="#ref-for-geolocation-2">(2)</a> <a href="#ref-for-geolocation-3">(3)</a> <a href="#ref-for-geolocation-4">(4)</a>
-    <li><a href="#ref-for-geolocation-5">Appendix A: Features</a>
+    <li><a href="#ref-for-geolocation-5">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-geolocation-6">geolocation</a> <a href="#ref-for-geolocation-7">(2)</a>
    </ul>
   </aside>
@@ -3047,14 +3056,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#microphone">#microphone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-microphone-1">2. Examples</a>
-    <li><a href="#ref-for-microphone-2">Appendix A: Features</a>
+    <li><a href="#ref-for-microphone-2">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-microphone-3">microphone</a> <a href="#ref-for-microphone-4">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="midi">
    <b><a href="#midi">#midi</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-midi-1">Appendix A: Features</a>
+    <li><a href="#ref-for-midi-1">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-midi-2">midi</a> <a href="#ref-for-midi-3">(2)</a>
    </ul>
   </aside>
@@ -3063,14 +3072,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-payment-1">8.5. Process feature policy
     attributes</a> <a href="#ref-for-payment-2">(2)</a>
-    <li><a href="#ref-for-payment-3">Appendix A: Features</a>
+    <li><a href="#ref-for-payment-3">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-payment-4">payment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="speaker">
    <b><a href="#speaker">#speaker</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-speaker-1">Appendix A: Features</a>
+    <li><a href="#ref-for-speaker-1">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-speaker-2">speaker</a> <a href="#ref-for-speaker-3">(2)</a>
    </ul>
   </aside>
@@ -3078,7 +3087,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#vibrate">#vibrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vibrate-1">2. Examples</a>
-    <li><a href="#ref-for-vibrate-2">Appendix A: Features</a>
+    <li><a href="#ref-for-vibrate-2">Appendix A: Policy-Controlled Features</a>
     <li><a href="#ref-for-vibrate-3">vibrate</a> <a href="#ref-for-vibrate-4">(2)</a>
    </ul>
   </aside>


### PR DESCRIPTION
This now uses the term "policy-controlled feature", but mentions that
the term "Feature" will be used as shorthand.

Fixes: #60