### PR TITLE
Reference features.md from spec; fix headings in features doc

### DIFF
--- a/features.md
+++ b/features.md
@@ -55,7 +55,7 @@ If disabled in any document, calls to both [`getCurrentPosition`](https://dev.w3
 * The **feature name** for *geolocation* is "`geolocation`"
 * The **default allowlist** for *geolocation* is `["self"]`.
 
-###microphone
+### microphone
 
 The *microphone* feature controls access to audio input devices requested through the [NavigatorUserMedia interface](https://w3c.github.io/mediacapture-main/getusermedia.html#navigatorusermedia).
 
@@ -64,7 +64,7 @@ If disabled in a document, then calls to [`getUserMedia()`](https://w3c.github.i
 * The **feature name** for *microphone* is "`microphone`"
 * The **default allowlist** for *microphone* is `["self"]`.
 
-###midi
+### midi
 
 The *midi* feature controls whether the current document is allowed to use the [Web MIDI API](https://webaudio.github.io/web-midi-api/).
 
@@ -73,7 +73,7 @@ If disabled in a document, the promise returned by [`requestMIDIAccess()`](https
 * The **feature name** for *midi* is "`midi`"
 * The **default allowlist** for *midi* is `["self"]`.
 
-###payment
+### payment
 
 The *payment* feature controls whether the current document is allowed to use the [PaymentRequest interface](https://w3c.github.io/browser-payment-api/).
 
@@ -82,7 +82,7 @@ If disabled in a document, then calls to the [`PaymentRequest` constuctor](https
 * The **feature name** for *payment* is "`payment`"
 * The **default allowlist** for *payment* is `["self"]`.
 
-###speaker
+### speaker
 
 The *speaker* feature controls access to audio output devices requested through the [NavigatorUserMedia interface](https://w3c.github.io/mediacapture-main/getusermedia.html#navigatorusermedia).
 
@@ -91,7 +91,7 @@ If disabled in a document, then calls to [`getUserMedia()`](https://w3c.github.i
 * The **feature name** for *speaker* is "`speaker`"
 * The **default allowlist** for *speaker* is `["self"]`.
 
-###vibrate
+### vibrate
 
 The *vibrate* feature controls whether the [Vibration API](https://w3c.github.io/vibration/) is allowed to cause device vibration.
 

--- a/index.bs
+++ b/index.bs
@@ -144,7 +144,9 @@ spec:fetch; type:dfn; text:value
     <a data-lt="policy-controlled feature">feature</a>.</p>
     <p>The <a>policy-controlled features</a> themselves are not themselves part
     of this framework. A non-normative list of currently-defined features is
-    included as an appendix to this specification.
+    maintained as a
+    <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
+    document</a> alongside this specification.
   </section>
   <section>
     <h3 id="policies">Policies</h3>

--- a/index.html
+++ b/index.html
@@ -1425,7 +1425,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-06-09">9 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-06-12">12 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1656,7 +1656,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     controlled through policies. User agents are not required to support every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-5">feature</a>.</p>
      <p>The <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-6">policy-controlled features</a> themselves are not themselves part
     of this framework. A non-normative list of currently-defined features is
-    included as an appendix to this specification. </p>
+    maintained as a <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
+    document</a> alongside this specification. </p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.2" id="policies"><span class="secno">4.2. </span><span class="content">Policies</span><a class="self-link" href="#policies"></a></h3>


### PR DESCRIPTION
The text of the spec still referred to the feature list as an appendix; also GitHub markup is less tolerant of missing spaces in section headings. so fixed those too.