### PR TITLE
Replace remaining instances of JSON-list syntax

### DIFF
--- a/features.md
+++ b/features.md
@@ -28,7 +28,7 @@ The *camera* feature controls access to video input devices requested through th
 If disabled in a document, then calls to [`getUserMedia()`](https://w3c.github.io/mediacapture-main/getusermedia.html#dom-mediadevices-getusermedia()) MUST NOT grant access to video input devices in that document.
 
 * The **feature name** for *camera* is "`camera`"
-* The **default allowlist** for *camera* is `["self"]`.
+* The **default allowlist** for *camera* is `'self'`.
 
 ### encrypted-media
 
@@ -37,7 +37,7 @@ The *encrypted-media* feature controls whether [encrypted media extensions](http
 If disabled in a document, the promise returned by [`requestMediaKeySystemAccess()`](https://w3c.github.io/encrypted-media/#navigator-extension-requestmediakeysystemaccess) must reject with a `NotSupportedError`.
 
 * The **feature name** for *encrypted-media* is "`encrypted-media`"
-* The **default allowlist** for *encrypted-media* is `["self"]`.
+* The **default allowlist** for *encrypted-media* is `'self'`.
 
 ### fullscreen
 
@@ -46,7 +46,7 @@ The *fullscreen* feature controls whether the [`requestFullscreen()`](https://fu
 If disabled in any document, the document will not be allowed to use fullscreen. If enabled, the document will be allowed to use fullscreen.
 
 * The **feature name** for *fullscreen* is "`fullscreen`"
-* The **default allowlist** for *fullscreen* is `["self"]`.
+* The **default allowlist** for *fullscreen* is `'self'`.
 
 ### geolocation
 
@@ -55,7 +55,7 @@ The *geolocation* feature controls whether the current document is allowed to us
 If disabled in any document, calls to both [`getCurrentPosition`](https://dev.w3.org/geo/api/spec-source.html#get-current-position) and [`watchPosition`](https://dev.w3.org/geo/api/spec-source.html#watch-position) must result in the error callback being invoked with `PERMISSION_DENIED`.
 
 * The **feature name** for *geolocation* is "`geolocation`"
-* The **default allowlist** for *geolocation* is `["self"]`.
+* The **default allowlist** for *geolocation* is `'self'`.
 
 ### microphone
 
@@ -64,7 +64,7 @@ The *microphone* feature controls access to audio input devices requested throug
 If disabled in a document, then calls to [`getUserMedia()`](https://w3c.github.io/mediacapture-main/getusermedia.html#dom-mediadevices-getusermedia()) MUST NOT grant access to audio input devices in that document.
 
 * The **feature name** for *microphone* is "`microphone`"
-* The **default allowlist** for *microphone* is `["self"]`.
+* The **default allowlist** for *microphone* is `'self'`.
 
 ### midi
 
@@ -73,7 +73,7 @@ The *midi* feature controls whether the current document is allowed to use the [
 If disabled in a document, the promise returned by [`requestMIDIAccess()`](https://webaudio.github.io/web-midi-api/#dom-navigator-requestmidiaccess) must reject with a `DOMException` parameter.
 
 * The **feature name** for *midi* is "`midi`"
-* The **default allowlist** for *midi* is `["self"]`.
+* The **default allowlist** for *midi* is `'self'`.
 
 ### payment
 
@@ -82,7 +82,7 @@ The *payment* feature controls whether the current document is allowed to use th
 If disabled in a document, then calls to the [`PaymentRequest` constuctor](https://w3c.github.io/browser-payment-api/#constructor) MUST throw a `SecurityError`.
 
 * The **feature name** for *payment* is "`payment`"
-* The **default allowlist** for *payment* is `["self"]`.
+* The **default allowlist** for *payment* is `'self'`.
 
 ### speaker
 
@@ -91,7 +91,7 @@ The *speaker* feature controls access to audio output devices requested through 
 If disabled in a document, then calls to [`getUserMedia()`](https://w3c.github.io/mediacapture-main/getusermedia.html#dom-mediadevices-getusermedia()) MUST NOT grant access to audio output devices in that document.
 
 * The **feature name** for *speaker* is "`speaker`"
-* The **default allowlist** for *speaker* is `["self"]`.
+* The **default allowlist** for *speaker* is `'self'`.
 
 ### usb
 
@@ -100,7 +100,7 @@ The *usb* feature controls whether the current document is allowed to use the [W
 If disabled in a document, then calls to the [`getDevices()`](https://wicg.github.io/webusb/#dom-usb-getdevices) should return a promise which rejects with a SecurityError DOMException.
 
 * The **feature name** for *usb* is "`usb`"
-* The **default allowlist** for *usb* is `["self"]`.
+* The **default allowlist** for *usb* is `'self'`.
 
 ### vibrate
 
@@ -109,7 +109,7 @@ The *vibrate* feature controls whether the [Vibration API](https://w3c.github.io
 If disabled in a document, then calls to the [`vibrate()`](https://w3c.github.io/vibration/#dom-navigator-vibrate) method should silently do nothing. If enabled, the browser may allow the device to vibrate.
 
 * The **feature name** for *vibrate* is "`vibrate`"
-* The **default allowlist** for *vibrate* is `["self"]`.
+* The **default allowlist** for *vibrate* is `'self'`.
 
 ### vr
 
@@ -118,4 +118,4 @@ The *vr* feature controls whether the current document is allowed to use the [We
 If disabled in a document, then calls to the [`getVRDisplays()`](https://w3c.github.io/webvr/spec/1.1/#navigator-getvrdisplays-attribute) should return a promise which rejects with a SecurityError DOMException.
 
 * The **feature name** for *vr* is "`vr`"
-* The **default allowlist** for *vr* is `["self"]`.
+* The **default allowlist** for *vr* is `'self'`.

--- a/index.bs
+++ b/index.bs
@@ -256,15 +256,15 @@ spec:fetch; type:dfn; text:value
     <p>Features are currently defined to have one of these three <a>default
     allowlists</a>:</p>
     <dl>
-      <dt>["<code>*</code>"]</dt>
+      <dt><code>'*'</code></dt>
       <dd>The feature is allowed at the top level by default, and when allowed,
       is allowed by default to documents in child frames.</dd>
-      <dt>["<code>self</code>"]</dt>
+      <dt><code>'self'</code></dt>
       <dd>The feature is allowed at the top level by default, and when allowed,
       is allowed by default to same-origin domain documents in child frames,
       but is disallowed by default in cross-origin documents in child
       frames.</dd>
-      <dt>[]</dt>
+      <dt>'none'</dt>
       <dd>The feature is disallowed at the top level by default, and is also
       disallowed by default to documents in child frames.</dd>
     </dl>
@@ -346,7 +346,7 @@ partial interface HTMLIFrameElement {
       value contains the token "<code>fullscreen</code>", then the
       "<code>allowfullscreen</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
-      will result in adding an <a>allowlist</a> of ["<code>*</code>"] for the
+      will result in adding an <a>allowlist</a> of <code>'*'</code> for the
       "fullscreen" feature to the frame's <a>container policy</a>, when it is
       constructed.</p>
       <div class="note">
@@ -366,7 +366,7 @@ partial interface HTMLIFrameElement {
       value contains the token "<code>payment</code>", then the
       "<code>allowpaymentrequest</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
-      iframe will result in adding an <a>allowlist</a> of ["<code>*</code>"] for
+      iframe will result in adding an <a>allowlist</a> of <code>'*'</code> for
       the "payment" feature to the frame's <a>container policy</a>, when it is
       constructed.</p>
       <div class="note">
@@ -715,10 +715,10 @@ partial interface HTMLIFrameElement {
         </ol>
       </li>
       <li>If <var>feature</var>'s <a>default allowlist</a> is
-      <code>["*"]</code>, return "<code>Enabled</code>".
+      <code>'*'</code>, return "<code>Enabled</code>".
       </li>
       <li>If <var>feature</var>'s <a>default allowlist</a> is
-      <code>["self"]</code>, and <var>origin</var> is [=same origin-domain=]
+      <code>'self'</code>, and <var>origin</var> is [=same origin-domain=]
       with <var>global</var>'s active document's origin, return
       "<code>Enabled</code>".
       </li>

--- a/index.bs
+++ b/index.bs
@@ -256,7 +256,7 @@ spec:fetch; type:dfn; text:value
     <p>Features are currently defined to have one of these three <a>default
     allowlists</a>:</p>
     <dl>
-      <dt><code>'*'</code></dt>
+      <dt><code>*</code></dt>
       <dd>The feature is allowed at the top level by default, and when allowed,
       is allowed by default to documents in child frames.</dd>
       <dt><code>'self'</code></dt>
@@ -346,7 +346,7 @@ partial interface HTMLIFrameElement {
       value contains the token "<code>fullscreen</code>", then the
       "<code>allowfullscreen</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
-      will result in adding an <a>allowlist</a> of <code>'*'</code> for the
+      will result in adding an <a>allowlist</a> of <code>*</code> for the
       "fullscreen" feature to the frame's <a>container policy</a>, when it is
       constructed.</p>
       <div class="note">
@@ -366,7 +366,7 @@ partial interface HTMLIFrameElement {
       value contains the token "<code>payment</code>", then the
       "<code>allowpaymentrequest</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
-      iframe will result in adding an <a>allowlist</a> of <code>'*'</code> for
+      iframe will result in adding an <a>allowlist</a> of <code>*</code> for
       the "payment" feature to the frame's <a>container policy</a>, when it is
       constructed.</p>
       <div class="note">
@@ -715,7 +715,7 @@ partial interface HTMLIFrameElement {
         </ol>
       </li>
       <li>If <var>feature</var>'s <a>default allowlist</a> is
-      <code>'*'</code>, return "<code>Enabled</code>".
+      <code>*</code>, return "<code>Enabled</code>".
       </li>
       <li>If <var>feature</var>'s <a>default allowlist</a> is
       <code>'self'</code>, and <var>origin</var> is [=same origin-domain=]

--- a/index.html
+++ b/index.html
@@ -1423,7 +1423,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-04">4 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-12">12 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1742,7 +1742,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <p>Features are currently defined to have one of these three <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-3">default
     allowlists</a>:</p>
      <dl>
-      <dt><code>'*'</code>
+      <dt><code>*</code>
       <dd>The feature is allowed at the top level by default, and when allowed,
       is allowed by default to documents in child frames.
       <dt><code>'self'</code>
@@ -1819,7 +1819,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       value contains the token "<code>fullscreen</code>", then the
       "<code>allowfullscreen</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
-      will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-8">allowlist</a> of <code>'*'</code> for the
+      will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-8">allowlist</a> of <code>*</code> for the
       "fullscreen" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-6">container policy</a>, when it is
       constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
@@ -1836,7 +1836,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       value contains the token "<code>payment</code>", then the
       "<code>allowpaymentrequest</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
-      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-9">allowlist</a> of <code>'*'</code> for
+      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-9">allowlist</a> of <code>*</code> for
       the "payment" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-7">container policy</a>, when it is
       constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
@@ -2106,7 +2106,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-12">allowlist</a> for <var>feature</var> in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-9">declared policy</a> <a data-link-type="dfn" href="#matches" id="ref-for-matches-2">matches</a> <var>origin</var>, then return "<code>Enabled</code>". 
         <li>Otherwise return "<code>Disabled</code>".
        </ol>
-      <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-4">default allowlist</a> is <code>'*'</code>, return "<code>Enabled</code>". 
+      <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-4">default allowlist</a> is <code>*</code>, return "<code>Enabled</code>". 
       <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-5">default allowlist</a> is <code>'self'</code>, and <var>origin</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">same origin-domain</a> with <var>global</var>’s active document’s origin, return
       "<code>Enabled</code>". 
       <li>Return "<code>Disabled</code>".

--- a/index.html
+++ b/index.html
@@ -1423,7 +1423,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-03">3 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-04">4 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1742,15 +1742,15 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <p>Features are currently defined to have one of these three <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-3">default
     allowlists</a>:</p>
      <dl>
-      <dt>["<code>*</code>"]
+      <dt><code>'*'</code>
       <dd>The feature is allowed at the top level by default, and when allowed,
       is allowed by default to documents in child frames.
-      <dt>["<code>self</code>"]
+      <dt><code>'self'</code>
       <dd>The feature is allowed at the top level by default, and when allowed,
       is allowed by default to same-origin domain documents in child frames,
       but is disallowed by default in cross-origin documents in child
       frames.
-      <dt>[]
+      <dt>'none'
       <dd>The feature is disallowed at the top level by default, and is also
       disallowed by default to documents in child frames.
      </dl>
@@ -1819,7 +1819,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       value contains the token "<code>fullscreen</code>", then the
       "<code>allowfullscreen</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
-      will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-8">allowlist</a> of ["<code>*</code>"] for the
+      will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-8">allowlist</a> of <code>'*'</code> for the
       "fullscreen" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-6">container policy</a>, when it is
       constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
@@ -1836,7 +1836,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       value contains the token "<code>payment</code>", then the
       "<code>allowpaymentrequest</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
-      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-9">allowlist</a> of ["<code>*</code>"] for
+      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-9">allowlist</a> of <code>'*'</code> for
       the "payment" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-7">container policy</a>, when it is
       constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
@@ -2106,8 +2106,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-12">allowlist</a> for <var>feature</var> in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-9">declared policy</a> <a data-link-type="dfn" href="#matches" id="ref-for-matches-2">matches</a> <var>origin</var>, then return "<code>Enabled</code>". 
         <li>Otherwise return "<code>Disabled</code>".
        </ol>
-      <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-4">default allowlist</a> is <code>["*"]</code>, return "<code>Enabled</code>". 
-      <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-5">default allowlist</a> is <code>["self"]</code>, and <var>origin</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">same origin-domain</a> with <var>global</var>’s active document’s origin, return
+      <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-4">default allowlist</a> is <code>'*'</code>, return "<code>Enabled</code>". 
+      <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist-5">default allowlist</a> is <code>'self'</code>, and <var>origin</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">same origin-domain</a> with <var>global</var>’s active document’s origin, return
       "<code>Enabled</code>". 
       <li>Return "<code>Disabled</code>".
      </ol>


### PR DESCRIPTION
There were a few places in the spec and feature list where an allowlist
was specified as ["self"], ["*"] or []. While not technically incorrect,
as they were not referring to the serialization of policies, they were
misleading. This replaces those with the hopefully less-misleading terms
from the new serialization: `'self'`, `*`, and `'none'`.

Fixes: #83