### PR TITLE
Don't claim that the spec defines feature names

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -143,11 +143,13 @@ spec:fetch; type:dfn; text:value
     of <a data-lt="policy-controlled feature">features</a> which it allows to be
     controlled through policies. User agents are not required to support every
     <a data-lt="policy-controlled feature">feature</a>.</p>
-    <p>The <a>policy-controlled features</a> themselves are not themselves part
-    of this framework. A non-normative list of currently-defined features is
-    maintained as a
-    <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
-    document</a> alongside this specification.
+    <div class="note">
+      The <a>policy-controlled features</a> themselves are not themselves part
+      of this framework. A non-normative list of currently-defined features is
+      maintained as a
+      <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
+      document</a> alongside this specification.
+    </div>
   </section>
   <section>
     <h3 id="policies">Policies</h3>
@@ -228,10 +230,13 @@ spec:fetch; type:dfn; text:value
     corresponding <a>allowlists</a> of origins.</p>
     <p>A <a>policy directive</a> is represented in HTTP headers and HTML
     attributes as its ASCII serialization.</p>
-    <p>The following sections define the set of known <a>feature names</a>.
-    Future versions of this document may define additional such names, as user
-    agents ignore policy directives with unrecognized names when parsing the
-    policy.</p>
+    <div class="note">
+      The allowed <a>feature names</a> are not defined by this specification.
+      A non-normative list of currently-defined features and their corresponding
+      names is maintained as a
+      <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
+      document</a> alongside this specification.
+    </div>
   </section>
   <section>
     <h3 id="allowlists">Allowlists</h3>

--- a/index.html
+++ b/index.html
@@ -1653,10 +1653,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <p>A user agent has a set of <dfn data-dfn-type="dfn" data-noexport="" id="supported-features">supported features<a class="self-link" href="#supported-features"></a></dfn>, which is the set
     of <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-4">features</a> which it allows to be
     controlled through policies. User agents are not required to support every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-5">feature</a>.</p>
-     <p>The <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-6">policy-controlled features</a> themselves are not themselves part
-    of this framework. A non-normative list of currently-defined features is
-    maintained as a <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
-    document</a> alongside this specification. </p>
+     <div class="note" role="note"> The <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature-6">policy-controlled features</a> themselves are not themselves part
+      of this framework. A non-normative list of currently-defined features is
+      maintained as a <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
+      document</a> alongside this specification. </div>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.2" id="policies"><span class="secno">4.2. </span><span class="content">Policies</span><a class="self-link" href="#policies"></a></h3>
@@ -1717,10 +1717,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     corresponding <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-3">allowlists</a> of origins.</p>
      <p>A <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-4">policy directive</a> is represented in HTTP headers and HTML
     attributes as its ASCII serialization.</p>
-     <p>The following sections define the set of known <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-2">feature names</a>.
-    Future versions of this document may define additional such names, as user
-    agents ignore policy directives with unrecognized names when parsing the
-    policy.</p>
+     <div class="note" role="note"> The allowed <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name-2">feature names</a> are not defined by this specification.
+      A non-normative list of currently-defined features and their corresponding
+      names is maintained as a <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
+      document</a> alongside this specification. </div>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.8" id="allowlists"><span class="secno">4.8. </span><span class="content">Allowlists</span><a class="self-link" href="#allowlists"></a></h3>


### PR DESCRIPTION
Explicitly mention again that this spec does not define the controlled features themselves, but point to the features.md doc that collects known ones.

Fixes #44