### PR TITLE
Clarify child inheritance

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -158,6 +158,24 @@ spec:fetch; type:dfn; text:value
       <li>A <a data-lt="declared policy">declared policy</a>.
       </li>
     </ul>
+    <p>The <a>feature policy</a> for a {{Document}} or {{WorkerGlobalScope}}
+    determines whether a feature is <a>allowed</a> or <a>disallowed</a> in that
+    context.</p>
+    <p>A feature which is <dfn>disallowed</dfn> should be disabled, or be made
+    unavailable for use in the Document or web worker. Each feature may have a
+    different mechanism for being disabled when <a>disallowed</a>, which should
+    be defined in that feature's specification.</p>
+    <p>A feature is <dfn>allowed</dfn> if it is not <a>disallowed</a>.</p>
+    <p>A feature may be <dfn>allowed by default</dfn> in a {{Document}} or
+    {{WorkerGlobalScope}}. If a feature is <a>allowed by default</a>, then it
+    is <a>allowed</a> unless a <a>declared policy</a> <a>disallows</a> it, or if
+    in a frame, if its <a>container policy</a> or its parent frame's
+    <a>feature policy</a> <a>disallows</a> it for that frame.</p>
+    <p>A feature may be <dfn>disallowed by default</dfn> in a {{Document}} or
+    {{WorkerGlobalScope}}. If a feature is <a>disallowed by default</a>, then it
+    is <a>disallowed</a> unless in a frame, in whose parent frame the feature is
+    <a>allowed</a>, and whose parent frame's <a>feature policy</a> or
+    <a>container policy</a> <a>allows</a> it.</p>
   </section>
   <section>
     <h3 id="inherited-policies">Inherited policies</h3>
@@ -256,16 +274,18 @@ spec:fetch; type:dfn; text:value
     allowlists</a>:</p>
     <dl>
       <dt>["<code>*</code>"]</dt>
-      <dd>The feature is allowed at the top level by default, and when allowed,
-      is allowed by default to documents in child frames.</dd>
+      <dd>The feature is <a>allowed by default</a> in top-level documents. If
+      allowed in a frame, the feature is <a>allowed by default</a> in that
+      frame's children.</dd>
       <dt>["<code>self</code>"]</dt>
-      <dd>The feature is allowed at the top level by default, and when allowed,
-      is allowed by default to same-origin domain documents in child frames,
-      but is disallowed by default in cross-origin documents in child
-      frames.</dd>
+      <dd>The feature is <a>allowed by default</a> in top-level documents. If
+      allowed in a frame, the feature is <a>allowed by default</a> in
+      same-origin documents in child frames, and is <a>disallowed by default</a>
+      in cross-origin documents in child frames.</dd>
       <dt>[]</dt>
-      <dd>The feature is disallowed at the top level by default, and is also
-      disallowed by default to documents in child frames.</dd>
+      <dd>The feature is <a>disallowed by default</a> in top-level documents,
+      and is also <a>disallowed by default</a> in documents in child frames.
+      </dd>
     </dl>
   </section>
 </section>

--- a/index.bs
+++ b/index.bs
@@ -168,14 +168,10 @@ spec:fetch; type:dfn; text:value
     <p>A feature is <dfn>allowed</dfn> if it is not <a>disallowed</a>.</p>
     <p>A feature may be <dfn>allowed by default</dfn> in a {{Document}} or
     {{WorkerGlobalScope}}. If a feature is <a>allowed by default</a>, then it
-    is <a>allowed</a> unless a <a>declared policy</a> <a>disallows</a> it, or if
-    in a frame, if its <a>container policy</a> or its parent frame's
-    <a>feature policy</a> <a>disallows</a> it for that frame.</p>
+    is <a>allowed</a> if no other policy disallows it.</p>
     <p>A feature may be <dfn>disallowed by default</dfn> in a {{Document}} or
     {{WorkerGlobalScope}}. If a feature is <a>disallowed by default</a>, then it
-    is <a>disallowed</a> unless in a frame, in whose parent frame the feature is
-    <a>allowed</a>, and whose parent frame's <a>feature policy</a> or
-    <a>container policy</a> <a>allows</a> it.</p>
+    is <a>disallowed</a> unless explicitly allowed by policy.</p>
   </section>
   <section>
     <h3 id="inherited-policies">Inherited policies</h3>
@@ -422,6 +418,35 @@ partial interface HTMLIFrameElement {
       </div>
     </section>
   </section>
+</section>
+<section>
+  <h2 id="combining-policies">Combining Policies from different sources</h2>
+  <p>To determine the effective feature policy for a given document, several
+  pieces of information are required:</p>
+  <ul>
+    <li>The default allowlists for all features supported by the user agent</li>
+    <li>The header policy for the document</li>
+    <li>The origin of the document</li>
+  </ul>
+  <p>If the document is in a frame, then this is also required:</p>
+  <ul>
+    <li>The feature policy of the document in the parent frame</li>
+    <li>The container policy defined for the document's frame by its parent.
+    </li>
+  </ul>
+  <p>Then, for each supported feature, we go through these steps:</p>
+  <ol>
+    <li>Use the parent's policy and the container policy to define the
+    <a>inherited policy</a> for the new document.
+    For each feature, if it is allowed by the parent for the new document's origin,
+    and not disallowed by the container policy, then it is enabled in the inherited policy. Otherwise, it is disabled.</li>
+    <li>Use the inherited policy and the document's header policy to determine the
+    effective policy for the new document.
+    For each feature, if it is disabled in the inherited policy, then its allowlist will be empty.
+    If it is enabled, and there is a declaration for that feature in the header policy, then its allowlist will be the declared list from the header.
+    If it is enabled, and there is no declaration for that feature in the header policy, then its allowlist will be the default allowlist for the feature (with 'self' replaced with the origin of the document).
+    </li>
+  </ol>
 </section>
 <section>
   <h2 id="integrations">Integrations</h2>

--- a/index.html
+++ b/index.html
@@ -1425,7 +1425,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-06-12">12 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-08-03">3 August 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1496,29 +1496,30 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#iframe-allowpaymentrequest-attribute"><span class="secno">6.3.2</span> <span class="content">allowpaymentrequest</span></a>
        </ol>
      </ol>
+    <li><a href="#combining-policies"><span class="secno">7</span> <span class="content">Combining Policies from different sources</span></a>
     <li>
-     <a href="#integrations"><span class="secno">7</span> <span class="content">Integrations</span></a>
+     <a href="#integrations"><span class="secno">8</span> <span class="content">Integrations</span></a>
      <ol class="toc">
-      <li><a href="#integration-with-html"><span class="secno">7.1</span> <span class="content">Integration with HTML</span></a>
+      <li><a href="#integration-with-html"><span class="secno">8.1</span> <span class="content">Integration with HTML</span></a>
      </ol>
     <li>
-     <a href="#algorithms"><span class="secno">8</span> <span class="content">Algorithms</span></a>
+     <a href="#algorithms"><span class="secno">9</span> <span class="content">Algorithms</span></a>
      <ol class="toc">
-      <li><a href="#process-response-policy"><span class="secno">8.1</span> <span class="content">Process response policy</span></a>
-      <li><a href="#parse-header"><span class="secno">8.2</span> <span class="content">Parse header from <var>value</var> and <var>origin</var></span></a>
-      <li><a href="#parse-policy-directive"><span class="secno">8.3</span> <span class="content">Parse policy directive from <var>value</var> and <var>origin</var></span></a>
-      <li><a href="#merge-directive-with-declared-policy"><span class="secno">8.4</span> <span class="content">Merge directive with declared
+      <li><a href="#process-response-policy"><span class="secno">9.1</span> <span class="content">Process response policy</span></a>
+      <li><a href="#parse-header"><span class="secno">9.2</span> <span class="content">Parse header from <var>value</var> and <var>origin</var></span></a>
+      <li><a href="#parse-policy-directive"><span class="secno">9.3</span> <span class="content">Parse policy directive from <var>value</var> and <var>origin</var></span></a>
+      <li><a href="#merge-directive-with-declared-policy"><span class="secno">9.4</span> <span class="content">Merge directive with declared
     policy</span></a>
-      <li><a href="#process-feature-policy-attributes"><span class="secno">8.5</span> <span class="content">Process feature policy
+      <li><a href="#process-feature-policy-attributes"><span class="secno">9.5</span> <span class="content">Process feature policy
     attributes</span></a>
-      <li><a href="#parse-allow-attribute"><span class="secno">8.6</span> <span class="content">Parse allow attribute</span></a>
-      <li><a href="#initialize-for-global"><span class="secno">8.7</span> <span class="content">Initialize <var>global</var>’s Feature
+      <li><a href="#parse-allow-attribute"><span class="secno">9.6</span> <span class="content">Parse allow attribute</span></a>
+      <li><a href="#initialize-for-global"><span class="secno">9.7</span> <span class="content">Initialize <var>global</var>’s Feature
     Policy from <var>response</var></span></a>
-      <li><a href="#define-inherited-policy"><span class="secno">8.8</span> <span class="content">Define an inherited policy for <var>feature</var></span></a>
-      <li><a href="#is-feature-enabled"><span class="secno">8.9</span> <span class="content">Is <var>feature</var> enabled in <var>global</var> for <var>origin</var>?</span></a>
+      <li><a href="#define-inherited-policy"><span class="secno">9.8</span> <span class="content">Define an inherited policy for <var>feature</var></span></a>
+      <li><a href="#is-feature-enabled"><span class="secno">9.9</span> <span class="content">Is <var>feature</var> enabled in <var>global</var> for <var>origin</var>?</span></a>
      </ol>
-    <li><a href="#iana-considerations"><span class="secno">9</span> <span class="content">IANA Considerations</span></a>
-    <li><a href="#privacy-and-security"><span class="secno">10</span> <span class="content">Privacy and Security</span></a>
+    <li><a href="#iana-considerations"><span class="secno">10</span> <span class="content">IANA Considerations</span></a>
+    <li><a href="#privacy-and-security"><span class="secno">11</span> <span class="content">Privacy and Security</span></a>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
@@ -1667,6 +1668,17 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>A set of <a data-link-type="dfn" href="#inherited-policy-set" id="ref-for-inherited-policy-set-1">inherited policies</a>. 
       <li>A <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-1">declared policy</a>. 
      </ul>
+     <p>The <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-2">feature policy</a> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> determines whether a feature is <a data-link-type="dfn" href="#allowed" id="ref-for-allowed-1">allowed</a> or <a data-link-type="dfn" href="#disallowed" id="ref-for-disallowed-1">disallowed</a> in that
+    context.</p>
+     <p>A feature which is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="disallowed">disallowed</dfn> should be disabled, or be made
+    unavailable for use in the Document or web worker. Each feature may have a
+    different mechanism for being disabled when <a data-link-type="dfn" href="#disallowed" id="ref-for-disallowed-2">disallowed</a>, which should
+    be defined in that feature’s specification.</p>
+     <p>A feature is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed">allowed</dfn> if it is not <a data-link-type="dfn" href="#disallowed" id="ref-for-disallowed-3">disallowed</a>.</p>
+     <p>A feature may be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed-by-default">allowed by default</dfn> in a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>. If a feature is <a data-link-type="dfn" href="#allowed-by-default" id="ref-for-allowed-by-default-1">allowed by default</a>, then it
+    is <a data-link-type="dfn" href="#allowed" id="ref-for-allowed-2">allowed</a> if no other policy disallows it.</p>
+     <p>A feature may be <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="disallowed-by-default">disallowed by default</dfn> in a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>. If a feature is <a data-link-type="dfn" href="#disallowed-by-default" id="ref-for-disallowed-by-default-1">disallowed by default</a>, then it
+    is <a data-link-type="dfn" href="#disallowed" id="ref-for-disallowed-4">disallowed</a> unless explicitly allowed by policy.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.3" id="inherited-policies"><span class="secno">4.3. </span><span class="content">Inherited policies</span><a class="self-link" href="#inherited-policies"></a></h3>
@@ -1694,7 +1706,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="4.5" id="header-policies"><span class="secno">4.5. </span><span class="content">Header policies</span><a class="self-link" href="#header-policies"></a></h3>
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="header-policy">header policy</dfn> is a list of <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-2">policy directives</a> delivered via an HTTP header with the document. This forms the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-2">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-4">declared policy</a>.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="header-policy">header policy</dfn> is a list of <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-2">policy directives</a> delivered via an HTTP header with the document. This forms the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-3">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-4">declared policy</a>.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.6" id="container-policies"><span class="secno">4.6. </span><span class="content">Container policies</span><a class="self-link" href="#container-policies"></a></h3>
@@ -1702,7 +1714,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     policy</dfn>, which is a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-3">policy directive</a>, which may be empty. The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-1">container policy</a> can set by attributes on the browsing context
     container.</p>
      <p>The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-2">container policy</a> for a frame influences the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-2">inherited
-    policy</a> of any document loaded into that frame. (See <a href="#define-inherited-policy">§8.8 Define an inherited policy for
+    policy</a> of any document loaded into that frame. (See <a href="#define-inherited-policy">§9.8 Define an inherited policy for
     feature</a>)</p>
      <div class="note" role="note"> Currently, the <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy-3">container policy</a> cannot be set directly, but is
       indirectly set by <code>iframe</code> "<a href="#iframe-allowfullscreen-attribute"><code>allowfullscreen</code></a>",
@@ -1744,16 +1756,16 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     allowlists</a>:</p>
      <dl>
       <dt>["<code>*</code>"]
-      <dd>The feature is allowed at the top level by default, and when allowed,
-      is allowed by default to documents in child frames.
+      <dd>The feature is <a data-link-type="dfn" href="#allowed-by-default" id="ref-for-allowed-by-default-2">allowed by default</a> in top-level documents. If
+      allowed in a frame, the feature is <a data-link-type="dfn" href="#allowed-by-default" id="ref-for-allowed-by-default-3">allowed by default</a> in that
+      frame’s children.
       <dt>["<code>self</code>"]
-      <dd>The feature is allowed at the top level by default, and when allowed,
-      is allowed by default to same-origin domain documents in child frames,
-      but is disallowed by default in cross-origin documents in child
-      frames.
+      <dd>The feature is <a data-link-type="dfn" href="#allowed-by-default" id="ref-for-allowed-by-default-4">allowed by default</a> in top-level documents. If
+      allowed in a frame, the feature is <a data-link-type="dfn" href="#allowed-by-default" id="ref-for-allowed-by-default-5">allowed by default</a> in
+      same-origin documents in child frames, and is <a data-link-type="dfn" href="#disallowed-by-default" id="ref-for-disallowed-by-default-2">disallowed by default</a> in cross-origin documents in child frames.
       <dt>[]
-      <dd>The feature is disallowed at the top level by default, and is also
-      disallowed by default to documents in child frames.
+      <dd>The feature is <a data-link-type="dfn" href="#disallowed-by-default" id="ref-for-disallowed-by-default-3">disallowed by default</a> in top-level documents,
+      and is also <a data-link-type="dfn" href="#disallowed-by-default" id="ref-for-disallowed-by-default-4">disallowed by default</a> in documents in child frames. 
      </dl>
     </section>
    </section>
@@ -2031,13 +2043,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="6.1" id="feature-policy-http-header-field"><span class="secno">6.1. </span><span class="content">Feature-Policy HTTP Header
     Field</span><a class="self-link" href="#feature-policy-http-header-field"></a></h3>
      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="feature-policy-header" data-noexport="" id="feature-policy-header">Feature-Policy</dfn> HTTP header
-    field can be used in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a> (server to client) to communicate the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-3">feature policy</a> that should be enforced by the client.</p>
+    field can be used in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a> (server to client) to communicate the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-4">feature policy</a> that should be enforced by the client.</p>
      <p>The header’s value is the <a href="#json-serialization">§5.1 JSON serialization</a> of one or
     more <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-6">policy directive</a>s:.</p>
 <pre class="abnf">FeaturePolicy = <a data-link-type="dfn" href="#policy-directive-json" id="ref-for-policy-directive-json-1">policy-directive-json</a> *("," <a data-link-type="dfn" href="#policy-directive-json" id="ref-for-policy-directive-json-2">policy-directive-json</a>)
 </pre>
      <p>When the user agent receives a <code>Feature-Policy</code> header field,
-    it MUST <a href="#process-response-policy">process</a> and <a data-link-type="dfn" href="#enforce" id="ref-for-enforce-1">enforce</a> the serialized policy as described in <a href="#integration-with-html">§7.1 Integration with HTML</a>.</p>
+    it MUST <a href="#process-response-policy">process</a> and <a data-link-type="dfn" href="#enforce" id="ref-for-enforce-1">enforce</a> the serialized policy as described in <a href="#integration-with-html">§8.1 Integration with HTML</a>.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.2" id="iframe-allow-attribute"><span class="secno">6.2. </span><span class="content">The <code>allow</code> attribute of the <code>iframe</code> element</span><a class="self-link" href="#iframe-allow-attribute"></a></h3>
@@ -2095,16 +2107,42 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
    </section>
    <section>
-    <h2 class="heading settled" data-level="7" id="integrations"><span class="secno">7. </span><span class="content">Integrations</span><a class="self-link" href="#integrations"></a></h2>
+    <h2 class="heading settled" data-level="7" id="combining-policies"><span class="secno">7. </span><span class="content">Combining Policies from different sources</span><a class="self-link" href="#combining-policies"></a></h2>
+    <p>To determine the effective feature policy for a given document, several
+  pieces of information are required:</p>
+    <ul>
+     <li>The default allowlists for all features supported by the user agent
+     <li>The header policy for the document
+     <li>The origin of the document
+    </ul>
+    <p>If the document is in a frame, then this is also required:</p>
+    <ul>
+     <li>The feature policy of the document in the parent frame
+     <li>The container policy defined for the document’s frame by its parent. 
+    </ul>
+    <p>Then, for each supported feature, we go through these steps:</p>
+    <ol>
+     <li>Use the parent’s policy and the container policy to define the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-3">inherited policy</a> for the new document.
+    For each feature, if it is allowed by the parent for the new document’s origin,
+    and not disallowed by the container policy, then it is enabled in the inherited policy. Otherwise, it is disabled.
+     <li>Use the inherited policy and the document’s header policy to determine the
+    effective policy for the new document.
+    For each feature, if it is disabled in the inherited policy, then its allowlist will be empty.
+    If it is enabled, and there is a declaration for that feature in the header policy, then its allowlist will be the declared list from the header.
+    If it is enabled, and there is no declaration for that feature in the header policy, then its allowlist will be the default allowlist for the feature (with 'self' replaced with the origin of the document). 
+    </ol>
+   </section>
+   <section>
+    <h2 class="heading settled" data-level="8" id="integrations"><span class="secno">8. </span><span class="content">Integrations</span><a class="self-link" href="#integrations"></a></h2>
     <p>This document defines a set of algorithms which other specifications will
   use in order to implement the restrictions which Feature Policy defines. The
   integrations are outlined here for clarity, but those external documents are
   the normative references which ought to be consulted for detailed
   information.</p>
     <section>
-     <h3 class="heading settled" data-level="7.1" id="integration-with-html"><span class="secno">7.1. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h3>
+     <h3 class="heading settled" data-level="8.1" id="integration-with-html"><span class="secno">8.1. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h3>
      <ol>
-      <li> <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> objects have a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-4">Feature Policy</a>, which is populated via the <a href="#initialize-for-global">§8.7 Initialize global’s Feature
+      <li> <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> objects have a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-5">Feature Policy</a>, which is populated via the <a href="#initialize-for-global">§9.7 Initialize global’s Feature
     Policy from response</a> algorithm that is called during the
         "Initialising a new <code>Document</code> object" and "Run a Worker"
         algorithms. 
@@ -2113,16 +2151,16 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <ul>
         <li> <a href="#initialize-for-global">Initialize the feature policy</a> for the <code>Document</code> 
        </ul>
-      <li>A <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-5">feature policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="enforce" data-noexport="" id="enforce">enforced</dfn> for
-      a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> by setting it as the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>'s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-6">Feature Policy</a>. 
+      <li>A <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-6">feature policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="enforce" data-noexport="" id="enforce">enforced</dfn> for
+      a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code> by setting it as the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>'s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-7">Feature Policy</a>. 
       <li>
-       <p>The "<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#allowed-to-use">allowed to use</a>" algorithm calls into <a href="#is-feature-enabled">§8.9 Is feature enabled in
+       <p>The "<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#allowed-to-use">allowed to use</a>" algorithm calls into <a href="#is-feature-enabled">§9.9 Is feature enabled in
     global for origin?</a>, as follows:</p>
        <ol>
         <li>
          Replace the current steps #3 and #4 with the following step: 
          <ul>
-          <li>If <code>Document</code>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-7">feature policy</a> enables the
+          <li>If <code>Document</code>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-8">feature policy</a> enables the
               feature indicated by <code>allowattribute</code> for the origin
               of <code>Document</code>, then return true. 
          </ul>
@@ -2133,9 +2171,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
    </section>
    <section>
-    <h2 class="heading settled" data-level="8" id="algorithms"><span class="secno">8. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
+    <h2 class="heading settled" data-level="9" id="algorithms"><span class="secno">9. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
     <section>
-     <h3 class="heading settled" data-level="8.1" id="process-response-policy"><span class="secno">8.1. </span><span class="content">Process response policy</span><a class="self-link" href="#process-response-policy"></a></h3>
+     <h3 class="heading settled" data-level="9.1" id="process-response-policy"><span class="secno">9.1. </span><span class="content">Process response policy</span><a class="self-link" href="#process-response-policy"></a></h3>
      <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a> (<var>response</var>) and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (<var>global</var>), this algorithm returns a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-5">declared feature
     policy</a>.</p>
      <ol>
@@ -2146,13 +2184,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       [RFC7230, 3.2.2]).
       <li>Add a leading "[" U+005B character, and a trailing "]" U+005D
       character to <var>header</var>.
-      <li>Let <var>feature policy</var> be the result of executing <a href="#parse-header">§8.2 Parse header from value and
+      <li>Let <var>feature policy</var> be the result of executing <a href="#parse-header">§9.2 Parse header from value and
     origin</a> on <var>header</var> and <var>global</var>’s origin. 
       <li>Return <var>feature policy</var>.
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="8.2" id="parse-header"><span class="secno">8.2. </span><span class="content">Parse header from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-header"></a></h3>
+     <h3 class="heading settled" data-level="9.2" id="parse-header"><span class="secno">9.2. </span><span class="content">Parse header from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-header"></a></h3>
      <p>Given a string (<var>value</var>) and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> (<var>origin</var>)
     this algorithm will return a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-6">declared feature policy</a>.</p>
      <ol>
@@ -2164,16 +2202,16 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        For each <var>element</var> of <var>list</var>: 
        <ol>
         <li>If <var>element</var> is not a JSON object, then continue.
-        <li>Let <var>directive</var> be the result of executing <a href="#parse-policy-directive">§8.3 Parse policy directive from
+        <li>Let <var>directive</var> be the result of executing <a href="#parse-policy-directive">§9.3 Parse policy directive from
     value and origin</a> on <var>element</var> and <var>origin</var> 
-        <li>Run <a href="#merge-directive-with-declared-policy">§8.4 Merge directive with declared
+        <li>Run <a href="#merge-directive-with-declared-policy">§9.4 Merge directive with declared
     policy</a> on <var> directive</var> and <var>policy</var>. 
        </ol>
       <li>Return <var>policy</var>.
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="8.3" id="parse-policy-directive"><span class="secno">8.3. </span><span class="content">Parse policy directive from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-policy-directive"></a></h3>
+     <h3 class="heading settled" data-level="9.3" id="parse-policy-directive"><span class="secno">9.3. </span><span class="content">Parse policy directive from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-policy-directive"></a></h3>
      <p>Given a JSON object (<var>value</var>) and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> (<var>origin</var>) this algorithm will return a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive-7">policy
     directive</a>.</p>
      <ol>
@@ -2207,7 +2245,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="8.4" id="merge-directive-with-declared-policy"><span class="secno">8.4. </span><span class="content">Merge directive with declared
+     <h3 class="heading settled" data-level="9.4" id="merge-directive-with-declared-policy"><span class="secno">9.4. </span><span class="content">Merge directive with declared
     policy</span><a class="self-link" href="#merge-directive-with-declared-policy"></a></h3>
      <p>Given a policy direcive (<var>directive</var>) and a declared policy
     (<var>policy</var>), this algorithm will modify <var>policy</var> to
@@ -2221,7 +2259,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="8.5" id="process-feature-policy-attributes"><span class="secno">8.5. </span><span class="content">Process feature policy
+     <h3 class="heading settled" data-level="9.5" id="process-feature-policy-attributes"><span class="secno">9.5. </span><span class="content">Process feature policy
     attributes</span><a class="self-link" href="#process-feature-policy-attributes"></a></h3>
      <p>Given an element <var>element</var>, this algorithm returns a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-7">declared feature policy</a>, which may be empty.</p>
      <ol>
@@ -2262,7 +2300,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="8.6" id="parse-allow-attribute"><span class="secno">8.6. </span><span class="content">Parse allow attribute</span><a class="self-link" href="#parse-allow-attribute"></a></h3>
+     <h3 class="heading settled" data-level="9.6" id="parse-allow-attribute"><span class="secno">9.6. </span><span class="content">Parse allow attribute</span><a class="self-link" href="#parse-allow-attribute"></a></h3>
      <p>Given a <var>list</var>, this algorithm returns a list of <a data-link-type="dfn">feature
     name keywords</a>, which may be empty.</p>
      <ol>
@@ -2283,36 +2321,36 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="8.7" id="initialize-for-global"><span class="secno">8.7. </span><span class="content">Initialize <var>global</var>’s Feature
+     <h3 class="heading settled" data-level="9.7" id="initialize-for-global"><span class="secno">9.7. </span><span class="content">Initialize <var>global</var>’s Feature
     Policy from <var>response</var></span><a class="self-link" href="#initialize-for-global"></a></h3>
      <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a> (<var>response</var>) and a global object
-    (<var>global</var>), this algorithm populates <var>global</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-8">Feature Policy</a></p>
+    (<var>global</var>), this algorithm populates <var>global</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-9">Feature Policy</a></p>
      <ol>
       <li>Let <var>inherited policies</var> be a new ordered map.
       <li>Let <var>declared policies</var> be a new ordered map.
       <li>
        For each <var>feature</var> supported, 
        <ol>
-        <li>Let <var>isInherited</var> be the result of running <a href="#define-inherited-policy">§8.8 Define an inherited policy for
+        <li>Let <var>isInherited</var> be the result of running <a href="#define-inherited-policy">§9.8 Define an inherited policy for
     feature</a> on <var>feature</var> and <var>global</var>. 
         <li>Set <var>inherited policies</var>[<var>feature</var>] to <var>isInherited</var>.
        </ol>
-      <li>Let <var>d</var> be the result of executing <a href="#process-response-policy">§8.1 Process response policy</a> on <var>response</var> and <var>global</var>. 
+      <li>Let <var>d</var> be the result of executing <a href="#process-response-policy">§9.1 Process response policy</a> on <var>response</var> and <var>global</var>. 
       <li>
        For each <var>feature</var> -> <var>allowlist</var> of <var>d</var>: 
        <ol>
         <li>If <var>inherited policies</var>[<var>feature</var>] is true, then
 	  set <var>declared policies</var>[<var>feature</var>] to <var>allowlist</var>.
        </ol>
-      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-9">feature policy</a>, with inherited
+      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-10">feature policy</a>, with inherited
       policy set <var>inherited policies</var> and declared policy set <var>declared policies</var>. 
       <li> <a data-link-type="dfn" href="#enforce" id="ref-for-enforce-2">Enforce</a> the policy <var>policy</var>. 
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="8.8" id="define-inherited-policy"><span class="secno">8.8. </span><span class="content">Define an inherited policy for <var>feature</var></span><a class="self-link" href="#define-inherited-policy"></a></h3>
+     <h3 class="heading settled" data-level="9.8" id="define-inherited-policy"><span class="secno">9.8. </span><span class="content">Define an inherited policy for <var>feature</var></span><a class="self-link" href="#define-inherited-policy"></a></h3>
      <p>Given a string (<var>feature</var>) and a browsing context
-    (<var>context</var>), this algorithm returns the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-3">inherited policy</a> for that feature.</p>
+    (<var>context</var>), this algorithm returns the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-4">inherited policy</a> for that feature.</p>
      <ol>
       <li>
        If <var>context</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing context</a>: 
@@ -2320,29 +2358,29 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>Let <var>parent</var> be <var>context</var>’s parent browsing
           context’s active document.
         <li>Let <var>origin</var> be <var>parent</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a>
-        <li>Let <var>container policy</var> be the result of running <a href="#process-feature-policy-attributes">§8.5 Process feature policy
+        <li>Let <var>container policy</var> be the result of running <a href="#process-feature-policy-attributes">§9.5 Process feature policy
     attributes</a> on <var>context</var>’s browsing context container. 
         <li>
          If <var>feature</var> is a key in <var>container policy</var>: 
          <ol>
-          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-12">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches-1">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-4">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
+          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist-12">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches-1">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-5">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
           <li>Otherwise return Disabled.
          </ol>
-        <li>Otherwise, if feature is allowed by <var>parent</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-10">feature policy</a> for <var>origin</var>, return Enabled. 
+        <li>Otherwise, if feature is allowed by <var>parent</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-11">feature policy</a> for <var>origin</var>, return Enabled. 
         <li>Otherwise, return Disabled.
        </ol>
       <li>Otherwise, return Enabled.
      </ol>
     </section>
     <section>
-     <h3 class="heading settled" data-level="8.9" id="is-feature-enabled"><span class="secno">8.9. </span><span class="content">Is <var>feature</var> enabled in <var>global</var> for <var>origin</var>?</span><a class="self-link" href="#is-feature-enabled"></a></h3>
+     <h3 class="heading settled" data-level="9.9" id="is-feature-enabled"><span class="secno">9.9. </span><span class="content">Is <var>feature</var> enabled in <var>global</var> for <var>origin</var>?</span><a class="self-link" href="#is-feature-enabled"></a></h3>
      <p>Given a string (<var>feature</var>) and a global object
     (<var>global</var>), and an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> (<var>origin</var>), this algorithm
     returns "<code>Disabled</code>" if <var>feature</var> should be considered
     disabled, and "<code>Enabled</code>" otherwise.</p>
      <ol>
-      <li>Let <var>policy</var> be <var>global</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-11">Feature Policy</a> 
-      <li>If <var>policy</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-5">inherited policy</a> for <var>feature</var> is Disabled, return "<code>Disabled</code>".
+      <li>Let <var>policy</var> be <var>global</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy-12">Feature Policy</a> 
+      <li>If <var>policy</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy-6">inherited policy</a> for <var>feature</var> is Disabled, return "<code>Disabled</code>".
       <li>
        If <var>feature</var> is present in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy-8">declared
       policy</a>: 
@@ -2358,7 +2396,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
    </section>
    <section>
-    <h2 class="heading settled" data-level="9" id="iana-considerations"><span class="secno">9. </span><span class="content">IANA Considerations</span><a class="self-link" href="#iana-considerations"></a></h2>
+    <h2 class="heading settled" data-level="10" id="iana-considerations"><span class="secno">10. </span><span class="content">IANA Considerations</span><a class="self-link" href="#iana-considerations"></a></h2>
     <p>The permanent message header field registry should be updated with the
   following registration <a data-link-type="biblio" href="#biblio-rfc3864">[RFC3864]</a>:</p>
     <dl>
@@ -2375,7 +2413,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </dl>
    </section>
    <section class="informative" id="privacy">
-    <h2 class="heading settled" data-level="10" id="privacy-and-security"><span class="secno">10. </span><span class="content">Privacy and Security</span><a class="self-link" href="#privacy-and-security"></a></h2>
+    <h2 class="heading settled" data-level="11" id="privacy-and-security"><span class="secno">11. </span><span class="content">Privacy and Security</span><a class="self-link" href="#privacy-and-security"></a></h2>
     <p class="issue" id="issue-b7b1e314"><a class="self-link" href="#issue-b7b1e314"></a>TODO</p>
    </section>
   </main>
@@ -2529,6 +2567,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#dom-htmliframeelement-allow">allow</a><span>, in §6.2</span>
+   <li><a href="#allowed">allowed</a><span>, in §4.2</span>
+   <li><a href="#allowed-by-default">allowed by default</a><span>, in §4.2</span>
    <li><a href="#allowlist">allowlist</a><span>, in §4.8</span>
    <li><a href="#allowlist">allowlists</a><span>, in §4.8</span>
    <li><a href="#container-policy">container policy</a><span>, in §4.6</span>
@@ -2536,7 +2576,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#declared-policy">declared policy</a><span>, in §4.4</span>
    <li><a href="#default-allowlist">default allowlist</a><span>, in §4.9</span>
    <li><a href="#default-allowlist">default allowlists</a><span>, in §4.9</span>
-   <li><a href="#enforce">enforce</a><span>, in §7.1</span>
+   <li><a href="#disallowed">disallowed</a><span>, in §4.2</span>
+   <li><a href="#disallowed-by-default">disallowed by default</a><span>, in §4.2</span>
+   <li><a href="#enforce">enforce</a><span>, in §8.1</span>
    <li><a href="#feature-name">feature name</a><span>, in §4.1</span>
    <li><a href="#feature-policy">feature policy</a><span>, in §4.2</span>
    <li><a href="#feature-policy-aware">feature-policy-aware</a><span>, in §4.4</span>
@@ -2655,7 +2697,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     iframe element</a>
     <li><a href="#ref-for-policy-controlled-feature-13">6.3. Additional attributes to support legacy
     features</a>
-    <li><a href="#ref-for-policy-controlled-feature-14">8.3. Parse policy directive from
+    <li><a href="#ref-for-policy-controlled-feature-14">9.3. Parse policy directive from
     value and origin</a> <a href="#ref-for-policy-controlled-feature-15">(2)</a>
    </ul>
   </aside>
@@ -2663,23 +2705,50 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#feature-name">#feature-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-name-1">4.7. Policy directives</a> <a href="#ref-for-feature-name-2">(2)</a>
-    <li><a href="#ref-for-feature-name-3">8.6. Parse allow attribute</a>
+    <li><a href="#ref-for-feature-name-3">9.6. Parse allow attribute</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="feature-policy">
    <b><a href="#feature-policy">#feature-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-policy-1">4.1. Policy-controlled Features</a>
-    <li><a href="#ref-for-feature-policy-2">4.5. Header policies</a>
-    <li><a href="#ref-for-feature-policy-3">6.1. Feature-Policy HTTP Header
+    <li><a href="#ref-for-feature-policy-2">4.2. Policies</a>
+    <li><a href="#ref-for-feature-policy-3">4.5. Header policies</a>
+    <li><a href="#ref-for-feature-policy-4">6.1. Feature-Policy HTTP Header
     Field</a>
-    <li><a href="#ref-for-feature-policy-4">7.1. Integration with HTML</a> <a href="#ref-for-feature-policy-5">(2)</a> <a href="#ref-for-feature-policy-6">(3)</a> <a href="#ref-for-feature-policy-7">(4)</a>
-    <li><a href="#ref-for-feature-policy-8">8.7. Initialize global’s Feature
-    Policy from response</a> <a href="#ref-for-feature-policy-9">(2)</a>
-    <li><a href="#ref-for-feature-policy-10">8.8. Define an inherited policy for
+    <li><a href="#ref-for-feature-policy-5">8.1. Integration with HTML</a> <a href="#ref-for-feature-policy-6">(2)</a> <a href="#ref-for-feature-policy-7">(3)</a> <a href="#ref-for-feature-policy-8">(4)</a>
+    <li><a href="#ref-for-feature-policy-9">9.7. Initialize global’s Feature
+    Policy from response</a> <a href="#ref-for-feature-policy-10">(2)</a>
+    <li><a href="#ref-for-feature-policy-11">9.8. Define an inherited policy for
     feature</a>
-    <li><a href="#ref-for-feature-policy-11">8.9. Is feature enabled in
+    <li><a href="#ref-for-feature-policy-12">9.9. Is feature enabled in
     global for origin?</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="disallowed">
+   <b><a href="#disallowed">#disallowed</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-disallowed-1">4.2. Policies</a> <a href="#ref-for-disallowed-2">(2)</a> <a href="#ref-for-disallowed-3">(3)</a> <a href="#ref-for-disallowed-4">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="allowed">
+   <b><a href="#allowed">#allowed</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-allowed-1">4.2. Policies</a> <a href="#ref-for-allowed-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="allowed-by-default">
+   <b><a href="#allowed-by-default">#allowed-by-default</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-allowed-by-default-1">4.2. Policies</a>
+    <li><a href="#ref-for-allowed-by-default-2">4.9. Default Allowlists</a> <a href="#ref-for-allowed-by-default-3">(2)</a> <a href="#ref-for-allowed-by-default-4">(3)</a> <a href="#ref-for-allowed-by-default-5">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="disallowed-by-default">
+   <b><a href="#disallowed-by-default">#disallowed-by-default</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-disallowed-by-default-1">4.2. Policies</a>
+    <li><a href="#ref-for-disallowed-by-default-2">4.9. Default Allowlists</a> <a href="#ref-for-disallowed-by-default-3">(2)</a> <a href="#ref-for-disallowed-by-default-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="inherited-policy">
@@ -2687,9 +2756,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-inherited-policy-1">4.3. Inherited policies</a>
     <li><a href="#ref-for-inherited-policy-2">4.6. Container policies</a>
-    <li><a href="#ref-for-inherited-policy-3">8.8. Define an inherited policy for
-    feature</a> <a href="#ref-for-inherited-policy-4">(2)</a>
-    <li><a href="#ref-for-inherited-policy-5">8.9. Is feature enabled in
+    <li><a href="#ref-for-inherited-policy-3">7. Combining Policies from different sources</a>
+    <li><a href="#ref-for-inherited-policy-4">9.8. Define an inherited policy for
+    feature</a> <a href="#ref-for-inherited-policy-5">(2)</a>
+    <li><a href="#ref-for-inherited-policy-6">9.9. Is feature enabled in
     global for origin?</a>
    </ul>
   </aside>
@@ -2706,12 +2776,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-declared-policy-2">4.3. Inherited policies</a>
     <li><a href="#ref-for-declared-policy-3">4.4. Declared policies</a>
     <li><a href="#ref-for-declared-policy-4">4.5. Header policies</a>
-    <li><a href="#ref-for-declared-policy-5">8.1. Process response policy</a>
-    <li><a href="#ref-for-declared-policy-6">8.2. Parse header from value and
+    <li><a href="#ref-for-declared-policy-5">9.1. Process response policy</a>
+    <li><a href="#ref-for-declared-policy-6">9.2. Parse header from value and
     origin</a>
-    <li><a href="#ref-for-declared-policy-7">8.5. Process feature policy
+    <li><a href="#ref-for-declared-policy-7">9.5. Process feature policy
     attributes</a>
-    <li><a href="#ref-for-declared-policy-8">8.9. Is feature enabled in
+    <li><a href="#ref-for-declared-policy-8">9.9. Is feature enabled in
     global for origin?</a> <a href="#ref-for-declared-policy-9">(2)</a>
    </ul>
   </aside>
@@ -2747,9 +2817,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-policy-directive-5">5.1. JSON serialization</a>
     <li><a href="#ref-for-policy-directive-6">6.1. Feature-Policy HTTP Header
     Field</a>
-    <li><a href="#ref-for-policy-directive-7">8.3. Parse policy directive from
+    <li><a href="#ref-for-policy-directive-7">9.3. Parse policy directive from
     value and origin</a>
-    <li><a href="#ref-for-policy-directive-8">8.5. Process feature policy
+    <li><a href="#ref-for-policy-directive-8">9.5. Process feature policy
     attributes</a>
    </ul>
   </aside>
@@ -2765,20 +2835,20 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     iframe element</a> <a href="#ref-for-allowlist-8">(2)</a>
     <li><a href="#ref-for-allowlist-9">6.3.1. allowfullscreen</a>
     <li><a href="#ref-for-allowlist-10">6.3.2. allowpaymentrequest</a>
-    <li><a href="#ref-for-allowlist-11">8.3. Parse policy directive from
+    <li><a href="#ref-for-allowlist-11">9.3. Parse policy directive from
     value and origin</a>
-    <li><a href="#ref-for-allowlist-12">8.8. Define an inherited policy for
+    <li><a href="#ref-for-allowlist-12">9.8. Define an inherited policy for
     feature</a>
-    <li><a href="#ref-for-allowlist-13">8.9. Is feature enabled in
+    <li><a href="#ref-for-allowlist-13">9.9. Is feature enabled in
     global for origin?</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="matches">
    <b><a href="#matches">#matches</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-matches-1">8.8. Define an inherited policy for
+    <li><a href="#ref-for-matches-1">9.8. Define an inherited policy for
     feature</a>
-    <li><a href="#ref-for-matches-2">8.9. Is feature enabled in
+    <li><a href="#ref-for-matches-2">9.9. Is feature enabled in
     global for origin?</a>
    </ul>
   </aside>
@@ -2787,7 +2857,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-default-allowlist-1">4.1. Policy-controlled Features</a>
     <li><a href="#ref-for-default-allowlist-2">4.9. Default Allowlists</a> <a href="#ref-for-default-allowlist-3">(2)</a>
-    <li><a href="#ref-for-default-allowlist-4">8.9. Is feature enabled in
+    <li><a href="#ref-for-default-allowlist-4">9.9. Is feature enabled in
     global for origin?</a> <a href="#ref-for-default-allowlist-5">(2)</a>
    </ul>
   </aside>
@@ -2809,7 +2879,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-enforce-1">6.1. Feature-Policy HTTP Header
     Field</a>
-    <li><a href="#ref-for-enforce-2">8.7. Initialize global’s Feature
+    <li><a href="#ref-for-enforce-2">9.7. Initialize global’s Feature
     Policy from response</a>
    </ul>
   </aside>


### PR DESCRIPTION
Make the descriptions of 'allowed by default' and 'disallowed by default' clearer, and explain in prose how parent policy, container policy and child declared policy are combined to form the effective feature policy in the child frame.

Fixes: #71