### PR TITLE
Update description and definition of allowlist.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -240,25 +240,44 @@ spec:fetch; type:dfn; text:value
   <section>
     <h3 id="allowlists">Allowlists</h3>
     <p>A feature policy <dfn lt="allowlist|allowlists">allowlist</dfn> is
-    a set of [=origins=]. An <a>allowlist</a> may be <em>empty</em>, in which
-    case it does not match any origin, or it may contain a list of origins, or
-    it may match every origin. When defining an allowlist in a policy, the
-    special string "self" may be used, which refers to the origin of the
-    document which the policy is associated with.</p>
-    <p>An <a>allowlist</a> <dfn>matches</dfn> an origin <var>o</var> if it
-    matches every origin, or if it contains an origin which is
-    [=same origin-domain=] with <var>o</var>.</p>
+    conceptually a set of [=origins=]. An <a>allowlist</a> may be either:
+    <ul>
+      <li><dfn>The special value <code>*</code></dfn>, which represents every
+      origin, or</li>
+      <li>An <a>ordered set</a> of [=origins=]</li>
+    </ul>
+    <div class="note">
+      The keywords <code>'self'</code>, <code>'src'</code>, and
+      <code>'none'</code> can appear in the text representation of allowlists in
+      headers and attribute strings. These keywords are always interpreted in
+      context during parsing, and only the origins which they refer to are
+      stored in the allowlist. The keywords themselves are not part of the
+      allowlist.
+    </div>
+    <p>To determine whether an <a>allowlist</a> <dfn>matches</dfn> an origin
+    <var>origin</var>, run these steps:
+    <ol>
+      <li>If the <a>allowlist</a> is <a>the special value <code>*</code></a>,
+      then return true.</li>
+      <li>Otherwise, for each <var>item</var> in the <a>allowlist</a>:
+        <ol>
+	  <li>If <var>item</var> is [=same origin-domain=] with
+	  <var>origin</var>, then return true.</li>
+	</ol>
+      </li>
+      <li>return false.</li>
+    </ol>
   </section>
   <section>
     <h3 id="default-allowlists">Default Allowlists</h3>
     <p>Every <a>policy-controlled feature</a> has a <dfn lt=
-    "default allowlist|default allowlists">default allowlist</dfn>, which is an
-    <a>allowlist</a>. The <a>default allowlist</a> controls the origins which
-    are allowed to access the feature when used in a top-level document with no
-    declared policy, and also determines whether access to the feature is
-    automatically delegated to child documents.</p>
-    <p>Features are currently defined to have one of these three <a>default
-    allowlists</a>:</p>
+    "default allowlist|default allowlists">default allowlist</dfn>. The
+    <a>default allowlist</a> controls the origins which are allowed to access
+    the feature when used in a top-level document with no declared policy, and
+    also determines whether access to the feature is automatically delegated to
+    child documents.</p>
+    <p>The <a>default allowlist</a> for a <a
+    data-lt="policy-controlled feature">feature</a> is one of these values:</p>
     <dl>
       <dt><code>*</code></dt>
       <dd>The feature is allowed at the top level by default, and when allowed,
@@ -577,20 +596,27 @@ partial interface HTMLIFrameElement {
 	  <var>tokens</var>.
           <li>Let <var>allowlist</var> be a new <a>allowlist</a>.
           </li>
-          <li>If <var>targetlist</var> contains the string "<code>*</code>",
-          set <var>allowlist</var> to match every origin.</li>
-          <li>Otherwise, for each <var>element</var> in <var>targetlist</var>:
-            <ol>
-              <li>If <var>element</var> is an ASCII case-insensitive match for
-              "<code>self</code>", let result be <var>origin</var>.</li>
-              <li>Otherwise, let <var>result</var> be the result of executing
-              the <a>URL parser</a> on <var>element</var>.</li>
-              <li>If <var>result</var> is not failure:
+          <li>If any element of <var>targetlist</var> is the string
+	  "<code>*</code>", set <var>allowlist</var> to <a>the special value
+	  <code>*</code></a>.</li>
+          <li>Otherwise:
+	    <ol>
+	      <li>Set <var>allowlist</var> to an new <a>ordered set</a>.</li>
+	      <li>For each <var>element</var> in <var>targetlist</var>:
                 <ol>
-                  <li>Let <var>target</var> be the origin of
-                  <var>result</var>.</li>
-                  <li>If <var>target</var> is not an opaque origin, append
-                  <var>target</var> to <var>allowlist</var>.</li>
+                  <li>If <var>element</var> is an <a>ASCII case-insensitive</a>
+		  match for the string "<code>self</code>", let result be
+		  <var>origin</var>.</li>
+                  <li>Otherwise, let <var>result</var> be the result of
+		  executing the <a>URL parser</a> on <var>element</var>.</li>
+                  <li>If <var>result</var> is not failure:
+                    <ol>
+                      <li>Let <var>target</var> be the origin of
+                      <var>result</var>.</li>
+                      <li>If <var>target</var> is not an opaque origin, append
+                      <var>target</var> to <var>allowlist</var>.</li>
+                    </ol>
+                  </li>
                 </ol>
               </li>
             </ol>
@@ -641,8 +667,7 @@ partial interface HTMLIFrameElement {
 	  allowlist for <code>fullscreen</code>,
             <ol>
               <li>Construct a new declaration for <code>fullscreen</code>, whose
-              allowlist matches all origins.
-              </li>
+              allowlist is <a>the special value <code>*</code></a>.</li>
               <li>Add <var>declaration</var> to <var>container policy</var>.
 	      </li>
             </ol>
@@ -652,8 +677,7 @@ partial interface HTMLIFrameElement {
 	  contain an allowlist for <code>payment</code>,
             <ol>
               <li>Construct a new declaration for <code>payment</code>, whose
-              allowlist matches all origins.
-              </li>
+              allowlist is <a>the special value <code>*</code></a>.</li>
               <li>Add <var>declaration</var> to <var>container policy</var>.
 	      </li>
             </ol>
@@ -665,8 +689,7 @@ partial interface HTMLIFrameElement {
 	      for <code>camera</code>,
                 <ol>
                   <li>Construct a new declaration for <code>camera</code>, whose
-                  allowlist matches all origins.
-                  </li>
+                  allowlist is <a>the special value <code>*</code></a>.</li>
                   <li>Add <var>declaration</var> to <var>policy</var>.</li>
                 </ol>
               </li>
@@ -674,8 +697,7 @@ partial interface HTMLIFrameElement {
 	      <code>microphone</code>,
                 <ol>
                   <li>Construct a new declaration for <code>microphone</code>,
-		  whose allowlist matches all origins.
-                  </li>
+                  allowlist is <a>the special value <code>*</code></a>.</li>
                   <li>Add <var>declaration</var> to <var>container policy</var>.
 		  </li>
                 </ol>
@@ -713,26 +735,32 @@ partial interface HTMLIFrameElement {
 	  <var>tokens</var>.
           <li>Let <var>allowlist</var> be a new <a>allowlist</a>.
           </li>
-          <li>If <var>targetlist</var> is empty, append <var>target origin</var>
-	  to <var>allowlist</var>.
-	  </li>
-	  <li>If <var>targetlist</var> contains the string "<code>*</code>",
-          set <var>allowlist</var> to match every origin.</li>
-          <li>Otherwise, for each <var>element</var> in <var>targetlist</var>:
-            <ol>
-              <li>If <var>element</var> is an ASCII case-insensitive match for
-              "<code>self</code>", let result be <var>container origin</var>.
-	      </li>
-              <li>If <var>element</var> is an ASCII case-insensitive match for
-	      "<code>src</code>", let result be <var>target origin</var>.</li>
-              <li>Otherwise, let <var>result</var> be the result of executing
-              the <a>URL parser</a> on <var>element</var>.</li>
-              <li>If <var>result</var> is not failure:
+          <li>If any element of <var>targetlist</var> is the string
+	  "<code>*</code>", set <var>allowlist</var> to <a>the special value
+	  <code>*</code></a>.</li>
+          <li>Otherwise:
+	    <ol>
+	      <li>Set <var>allowlist</var> to an new <a>ordered set</a>.</li>
+              <li>If <var>targetlist</var> is empty, append <var>target
+	      origin</var> to <var>allowlist</var>.
+	      <li>For each <var>element</var> in <var>targetlist</var>:
                 <ol>
-                  <li>Let <var>target</var> be the origin of
-                  <var>result</var>.</li>
-                  <li>If <var>target</var> is not an opaque origin, append
-                  <var>target</var> to <var>allowlist</var>.</li>
+                  <li>If <var>element</var> is an <a>ASCII case-insensitive</a>
+		  match for "<code>self</code>", let result be <var>container
+		  origin</var>.</li>
+                  <li>If <var>element</var> is an <a>ASCII case-insensitive</a>
+		  match for "<code>src</code>", let result be <var>target
+		  origin</var>.</li>
+		  <li>Otherwise, let <var>result</var> be the result of
+		  executing the <a>URL parser</a> on <var>element</var>.</li>
+                  <li>If <var>result</var> is not failure:
+                    <ol>
+                      <li>Let <var>target</var> be the origin of
+                      <var>result</var>.</li>
+                      <li>If <var>target</var> is not an opaque origin, append
+                      <var>target</var> to <var>allowlist</var>.</li>
+                    </ol>
+                  </li>
                 </ol>
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version b43bcf8d18510de03d8b56c5e878eea93e955427" name="generator">
   <link href="https://wicg.github.io/feature-policy/" rel="canonical">
-  <meta content="fab0f5e570196b908b92ae0108d1992cb6a26964" name="document-revision">
+  <meta content="b9331a5e2835f8fbeeb2d6e9a811ef8ea43bbd77" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-12-20">20 December 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-12-22">22 December 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1729,22 +1729,36 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="4.8" id="allowlists"><span class="secno">4.8. </span><span class="content">Allowlists</span><a class="self-link" href="#allowlists"></a></h3>
      <p>A feature policy <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="allowlist|allowlists" data-noexport="" id="allowlist">allowlist</dfn> is
-    a set of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origins</a>. An <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist③">allowlist</a> may be <em>empty</em>, in which
-    case it does not match any origin, or it may contain a list of origins, or
-    it may match every origin. When defining an allowlist in a policy, the
-    special string "self" may be used, which refers to the origin of the
-    document which the policy is associated with.</p>
-     <p>An <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist④">allowlist</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="matches">matches</dfn> an origin <var>o</var> if it
-    matches every origin, or if it contains an origin which is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain">same origin-domain</a> with <var>o</var>.</p>
+    conceptually a set of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin">origins</a>. An <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist③">allowlist</a> may be either: </p>
+     <ul>
+      <li><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="the-special-value">The special value <code>*</code></dfn>, which represents every
+      origin, or
+      <li>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">ordered set</a> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origins</a>
+     </ul>
+     <div class="note" role="note"> The keywords <code>'self'</code>, <code>'src'</code>, and <code>'none'</code> can appear in the text representation of allowlists in
+      headers and attribute strings. These keywords are always interpreted in
+      context during parsing, and only the origins which they refer to are
+      stored in the allowlist. The keywords themselves are not part of the
+      allowlist. </div>
+     <p>To determine whether an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist④">allowlist</a> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="matches">matches</dfn> an origin <var>origin</var>, run these steps: </p>
+     <ol>
+      <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑤">allowlist</a> is <a data-link-type="dfn" href="#the-special-value" id="ref-for-the-special-value">the special value <code>*</code></a>,
+      then return true.
+      <li>
+       Otherwise, for each <var>item</var> in the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑥">allowlist</a>: 
+       <ol>
+        <li>If <var>item</var> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain" id="ref-for-same-origin-domain">same origin-domain</a> with <var>origin</var>, then return true.
+       </ol>
+      <li>return false.
+     </ol>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.9" id="default-allowlists"><span class="secno">4.9. </span><span class="content">Default Allowlists</span><a class="self-link" href="#default-allowlists"></a></h3>
-     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①①">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>, which is an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑤">allowlist</a>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> controls the origins which
-    are allowed to access the feature when used in a top-level document with no
-    declared policy, and also determines whether access to the feature is
-    automatically delegated to child documents.</p>
-     <p>Features are currently defined to have one of these three <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist②">default
-    allowlists</a>:</p>
+     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①①">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> controls the origins which are allowed to access
+    the feature when used in a top-level document with no declared policy, and
+    also determines whether access to the feature is automatically delegated to
+    child documents.</p>
+     <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist②">default allowlist</a> for a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①②">feature</a> is one of these values:</p>
      <dl>
       <dt><code>*</code>
       <dd>The feature is allowed at the top level by default, and when allowed,
@@ -1807,12 +1821,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     that case, the default value for the allowlist is <code>'src'</code>, which
     represents the origin of the URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src" id="ref-for-attr-iframe-src">src</a></code> attribute. </p>
      <p>When not empty, the "<code>allow</code>" attribute will result in adding
-    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑥">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①②">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy④">container policy</a>, when it is contructed.</p>
+    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑦">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①③">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy④">container policy</a>, when it is contructed.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.3" id="legacy-attributes"><span class="secno">6.3. </span><span class="content">Additional attributes to support legacy
     features</span><a class="self-link" href="#legacy-attributes"></a></h3>
-     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①③">features</a> controlled by
+     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①④">features</a> controlled by
     Feature Policy have existing iframe attributes defined. This specification
     redefines these attributes to act as declared policies for the iframe
     element.</p>
@@ -1823,7 +1837,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       value contains the token "<code>fullscreen</code>", then the
       "<code>allowfullscreen</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
-      will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑦">allowlist</a> of <code>*</code> for the
+      will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑧">allowlist</a> of <code>*</code> for the
       "fullscreen" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑤">container policy</a>, when it is
       constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
@@ -1840,7 +1854,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       value contains the token "<code>payment</code>", then the
       "<code>allowpaymentrequest</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
-      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑧">allowlist</a> of <code>*</code> for
+      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑨">allowlist</a> of <code>*</code> for
       the "payment" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑥">container policy</a>, when it is
       constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
@@ -1856,7 +1870,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       value contains the token "<code>payment</code>", then the
       "<code>allowusermedia</code> attribute must have no effect.</p>
       <p>Otherwise, the presence of an "allowusermedia" attribute on an
-      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑨">allowlist</a> of <code>*</code> for
+      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①⓪">allowlist</a> of <code>*</code> for
       each of the "camera" and "microphone" features to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑦">container
       policy</a>, when it is constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
@@ -1963,7 +1977,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="8.2" id="parse-header"><span class="secno">8.2. </span><span class="content">Parse header from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-header"></a></h3>
-     <p>Given a string (<var>value</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin①">origin</a> (<var>origin</var>)
+     <p>Given a string (<var>value</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> (<var>origin</var>)
     this algorithm will return a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑥">declared feature policy</a>.</p>
      <ol>
       <li>Let <var>policy</var> be an empty ordered map.
@@ -1980,7 +1994,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="8.3" id="parse-policy-directive"><span class="secno">8.3. </span><span class="content">Parse policy directive from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-policy-directive"></a></h3>
-     <p>Given a string (<var>value</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> (<var>origin</var>)
+     <p>Given a string (<var>value</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin③">origin</a> (<var>origin</var>)
     this algorithm will return a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive⑦">policy directive</a>.</p>
      <ol>
       <li>Let <var>directive</var> be an empty ordered map.
@@ -1992,24 +2006,28 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>If <var>tokens</var> is an empty list, then continue.
         <li>Let <var>feature-name</var> be the first element of <var>tokens</var>.
         <li>If <var>feature-name</var> is not equal to the name of any
-	  recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①④">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑤">policy-controlled feature</a> named by <var>feature-name</var>.
+	  recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑤">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑥">policy-controlled feature</a> named by <var>feature-name</var>.
         <li>Let <var>targetlist</var> be the remaining elements, if any, of <var>tokens</var>. 
-        <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①⓪">allowlist</a>. 
-        <li>If <var>targetlist</var> contains the string "<code>*</code>",
-          set <var>allowlist</var> to match every origin.
+        <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①①">allowlist</a>. 
+        <li>If any element of <var>targetlist</var> is the string
+	  "<code>*</code>", set <var>allowlist</var> to <a data-link-type="dfn" href="#the-special-value" id="ref-for-the-special-value①">the special value <code>*</code></a>.
         <li>
-         Otherwise, for each <var>element</var> in <var>targetlist</var>: 
+         Otherwise: 
          <ol>
-          <li>If <var>element</var> is an ASCII case-insensitive match for
-              "<code>self</code>", let result be <var>origin</var>.
-          <li>Otherwise, let <var>result</var> be the result of executing
-              the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">URL parser</a> on <var>element</var>.
+          <li>Set <var>allowlist</var> to an new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">ordered set</a>.
           <li>
-           If <var>result</var> is not failure: 
+           For each <var>element</var> in <var>targetlist</var>: 
            <ol>
-            <li>Let <var>target</var> be the origin of <var>result</var>.
-            <li>If <var>target</var> is not an opaque origin, append <var>target</var> to <var>allowlist</var>.
+            <li>If <var>element</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive">ASCII case-insensitive</a> match for the string "<code>self</code>", let result be <var>origin</var>.
+            <li>Otherwise, let <var>result</var> be the result of
+		  executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">URL parser</a> on <var>element</var>.
+            <li>
+             If <var>result</var> is not failure: 
+             <ol>
+              <li>Let <var>target</var> be the origin of <var>result</var>.
+              <li>If <var>target</var> is not an opaque origin, append <var>target</var> to <var>allowlist</var>.
+             </ol>
            </ol>
          </ol>
         <li>Set <var>directive</var>[<var>feature</var>] to <var>allowlist</var>.
@@ -2049,7 +2067,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 	  allowlist for <code>fullscreen</code>, 
          <ol>
           <li>Construct a new declaration for <code>fullscreen</code>, whose
-              allowlist matches all origins. 
+              allowlist is <a data-link-type="dfn" href="#the-special-value" id="ref-for-the-special-value②">the special value <code>*</code></a>.
           <li>Add <var>declaration</var> to <var>container policy</var>. 
          </ol>
         <li>
@@ -2057,7 +2075,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 	  contain an allowlist for <code>payment</code>, 
          <ol>
           <li>Construct a new declaration for <code>payment</code>, whose
-              allowlist matches all origins. 
+              allowlist is <a data-link-type="dfn" href="#the-special-value" id="ref-for-the-special-value③">the special value <code>*</code></a>.
           <li>Add <var>declaration</var> to <var>container policy</var>. 
          </ol>
         <li>
@@ -2068,14 +2086,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 	      for <code>camera</code>, 
            <ol>
             <li>Construct a new declaration for <code>camera</code>, whose
-                  allowlist matches all origins. 
+                  allowlist is <a data-link-type="dfn" href="#the-special-value" id="ref-for-the-special-value④">the special value <code>*</code></a>.
             <li>Add <var>declaration</var> to <var>policy</var>.
            </ol>
           <li>
            If <var>policy</var> does not contain an allowlist for <code>microphone</code>, 
            <ol>
             <li>Construct a new declaration for <code>microphone</code>,
-		  whose allowlist matches all origins. 
+                  allowlist is <a data-link-type="dfn" href="#the-special-value" id="ref-for-the-special-value⑤">the special value <code>*</code></a>.
             <li>Add <var>declaration</var> to <var>container policy</var>. 
            </ol>
          </ol>
@@ -2098,27 +2116,33 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>If <var>tokens</var> is an empty list, then continue.
         <li>Let <var>feature-name</var> be the first element of <var>tokens</var>.
         <li>If <var>feature-name</var> is not equal to the name of any
-	  recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑥">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑦">policy-controlled feature</a> named by <var>feature-name</var>.
+	  recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑦">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑧">policy-controlled feature</a> named by <var>feature-name</var>.
         <li>Let <var>targetlist</var> be the remaining elements, if any, of <var>tokens</var>. 
-        <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①①">allowlist</a>. 
-        <li>If <var>targetlist</var> is empty, append <var>target origin</var> to <var>allowlist</var>. 
-        <li>If <var>targetlist</var> contains the string "<code>*</code>",
-          set <var>allowlist</var> to match every origin.
+        <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①②">allowlist</a>. 
+        <li>If any element of <var>targetlist</var> is the string
+	  "<code>*</code>", set <var>allowlist</var> to <a data-link-type="dfn" href="#the-special-value" id="ref-for-the-special-value⑥">the special value <code>*</code></a>.
         <li>
-         Otherwise, for each <var>element</var> in <var>targetlist</var>: 
+         Otherwise: 
          <ol>
-          <li>If <var>element</var> is an ASCII case-insensitive match for
-              "<code>self</code>", let result be <var>container origin</var>. 
-          <li>If <var>element</var> is an ASCII case-insensitive match for
-	      "<code>src</code>", let result be <var>target origin</var>.
-          <li>Otherwise, let <var>result</var> be the result of executing
-              the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on <var>element</var>.
+          <li>Set <var>allowlist</var> to an new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">ordered set</a>.
+          <li>If <var>targetlist</var> is empty, append <var>target
+	      origin</var> to <var>allowlist</var>. 
           <li>
-           If <var>result</var> is not failure: 
+           For each <var>element</var> in <var>targetlist</var>: 
            <ol>
-            <li>Let <var>target</var> be the origin of <var>result</var>.
-            <li>If <var>target</var> is not an opaque origin, append <var>target</var> to <var>allowlist</var>.
+            <li>If <var>element</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①">ASCII case-insensitive</a> match for "<code>self</code>", let result be <var>container
+		  origin</var>.
+            <li>If <var>element</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for "<code>src</code>", let result be <var>target
+		  origin</var>.
+            <li>Otherwise, let <var>result</var> be the result of
+		  executing the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser①">URL parser</a> on <var>element</var>.
+            <li>
+             If <var>result</var> is not failure: 
+             <ol>
+              <li>Let <var>target</var> be the origin of <var>result</var>.
+              <li>If <var>target</var> is not an opaque origin, append <var>target</var> to <var>allowlist</var>.
+             </ol>
            </ol>
          </ol>
         <li>Set <var>directive</var>[<var>feature</var>] to <var>allowlist</var>.
@@ -2177,13 +2201,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <ol>
         <li>Let <var>parent</var> be <var>context</var>’s parent browsing
           context’s active document.
-        <li>Let <var>origin</var> be <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin③">origin</a>
+        <li>Let <var>origin</var> be <var>parent</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin④">origin</a>
         <li>Let <var>container policy</var> be the result of running <a href="#process-feature-policy-attributes">§8.5 Process feature policy
     attributes</a> on <var>context</var>’s browsing context container. 
         <li>
          If <var>feature</var> is a key in <var>container policy</var>: 
          <ol>
-          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①②">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy③">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
+          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①③">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy③">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
           <li>Otherwise return Disabled.
          </ol>
         <li>Otherwise, if feature is enabled in <var>parent</var> for <var>origin</var>, return Enabled. 
@@ -2195,7 +2219,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="8.10" id="is-feature-enabled"><span class="secno">8.10. </span><span class="content">Is <var>feature</var> enabled in <var>document</var> for <var>origin</var>?</span><a class="self-link" href="#is-feature-enabled"></a></h3>
      <p>Given a string (<var>feature</var>) and a Document object
-    (<var>document</var>), and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin④">origin</a> (<var>origin</var>), this algorithm
+    (<var>document</var>), and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin⑤">origin</a> (<var>origin</var>), this algorithm
     returns "<code>Disabled</code>" if <var>feature</var> should be considered
     disabled, and "<code>Enabled</code>" otherwise.</p>
      <ol>
@@ -2205,7 +2229,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        If <var>feature</var> is present in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑦">declared
       policy</a>: 
        <ol>
-        <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①③">allowlist</a> for <var>feature</var> in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑧">declared policy</a> <a data-link-type="dfn" href="#matches" id="ref-for-matches①">matches</a> <var>origin</var>, then return "<code>Enabled</code>". 
+        <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①④">allowlist</a> for <var>feature</var> in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑧">declared policy</a> <a data-link-type="dfn" href="#matches" id="ref-for-matches①">matches</a> <var>origin</var>, then return "<code>Enabled</code>". 
         <li>Otherwise return "<code>Disabled</code>".
        </ol>
       <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist③">default allowlist</a> is <code>*</code>, return "<code>Enabled</code>". 
@@ -2387,8 +2411,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <ul class="index">
    <li><a href="#dom-htmliframeelement-allow">allow</a><span>, in §6.2</span>
    <li><a href="#allowed-to-use">allowed to use</a><span>, in §7.1</span>
-   <li><a href="#allowlist">allowlist</a><span>, in §4.8</span>
    <li><a href="#allow-list">allow-list</a><span>, in §5.1</span>
+   <li><a href="#allowlist">allowlist</a><span>, in §4.8</span>
    <li><a href="#allowlist">allowlists</a><span>, in §4.8</span>
    <li><a href="#allow-list-value">allow-list-value</a><span>, in §5.1</span>
    <li><a href="#container-policy">container policy</a><span>, in §4.6</span>
@@ -2415,6 +2439,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#serialized-feature-policy">serialized-feature-policy</a><span>, in §5.1</span>
    <li><a href="#serialized-policy-directive">serialized-policy-directive</a><span>, in §5.1</span>
    <li><a href="#supported-features">supported features</a><span>, in §4.1</span>
+   <li><a href="#the-special-value">The special value *</a><span>, in §4.8</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -2466,6 +2491,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
+     <li><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
+     <li><a href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>
      <li><a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">split on ascii whitespace</a>
      <li><a href="https://infra.spec.whatwg.org/#split-on-commas">split on commas</a>
      <li><a href="https://infra.spec.whatwg.org/#strictly-split">strictly split</a>
@@ -2532,14 +2559,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-policy-controlled-feature⑥">4.2. Policies</a>
     <li><a href="#ref-for-policy-controlled-feature⑦">4.3. Inherited policies</a> <a href="#ref-for-policy-controlled-feature⑧">(2)</a> <a href="#ref-for-policy-controlled-feature⑨">(3)</a>
     <li><a href="#ref-for-policy-controlled-feature①⓪">4.4. Declared policies</a>
-    <li><a href="#ref-for-policy-controlled-feature①①">4.9. Default Allowlists</a>
-    <li><a href="#ref-for-policy-controlled-feature①②">6.2. The allow attribute of the
+    <li><a href="#ref-for-policy-controlled-feature①①">4.9. Default Allowlists</a> <a href="#ref-for-policy-controlled-feature①②">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①③">6.2. The allow attribute of the
     iframe element</a>
-    <li><a href="#ref-for-policy-controlled-feature①③">6.3. Additional attributes to support legacy
+    <li><a href="#ref-for-policy-controlled-feature①④">6.3. Additional attributes to support legacy
     features</a>
-    <li><a href="#ref-for-policy-controlled-feature①④">8.3. Parse policy directive from
-    value and origin</a> <a href="#ref-for-policy-controlled-feature①⑤">(2)</a>
-    <li><a href="#ref-for-policy-controlled-feature①⑥">8.6. Parse allow attribute</a> <a href="#ref-for-policy-controlled-feature①⑦">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①⑤">8.3. Parse policy directive from
+    value and origin</a> <a href="#ref-for-policy-controlled-feature①⑥">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①⑦">8.6. Parse allow attribute</a> <a href="#ref-for-policy-controlled-feature①⑧">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="feature-name">
@@ -2651,20 +2678,30 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-allowlist">2. Examples</a>
     <li><a href="#ref-for-allowlist①">4.4. Declared policies</a>
     <li><a href="#ref-for-allowlist②">4.7. Policy directives</a>
-    <li><a href="#ref-for-allowlist③">4.8. Allowlists</a> <a href="#ref-for-allowlist④">(2)</a>
-    <li><a href="#ref-for-allowlist⑤">4.9. Default Allowlists</a>
-    <li><a href="#ref-for-allowlist⑥">6.2. The allow attribute of the
+    <li><a href="#ref-for-allowlist③">4.8. Allowlists</a> <a href="#ref-for-allowlist④">(2)</a> <a href="#ref-for-allowlist⑤">(3)</a> <a href="#ref-for-allowlist⑥">(4)</a>
+    <li><a href="#ref-for-allowlist⑦">6.2. The allow attribute of the
     iframe element</a>
-    <li><a href="#ref-for-allowlist⑦">6.3.1. allowfullscreen</a>
-    <li><a href="#ref-for-allowlist⑧">6.3.2. allowpaymentrequest</a>
-    <li><a href="#ref-for-allowlist⑨">6.3.3. allowusermedia</a>
-    <li><a href="#ref-for-allowlist①⓪">8.3. Parse policy directive from
+    <li><a href="#ref-for-allowlist⑧">6.3.1. allowfullscreen</a>
+    <li><a href="#ref-for-allowlist⑨">6.3.2. allowpaymentrequest</a>
+    <li><a href="#ref-for-allowlist①⓪">6.3.3. allowusermedia</a>
+    <li><a href="#ref-for-allowlist①①">8.3. Parse policy directive from
     value and origin</a>
-    <li><a href="#ref-for-allowlist①①">8.6. Parse allow attribute</a>
-    <li><a href="#ref-for-allowlist①②">8.9. Define an inherited policy for
+    <li><a href="#ref-for-allowlist①②">8.6. Parse allow attribute</a>
+    <li><a href="#ref-for-allowlist①③">8.9. Define an inherited policy for
     feature</a>
-    <li><a href="#ref-for-allowlist①③">8.10. Is feature enabled in
+    <li><a href="#ref-for-allowlist①④">8.10. Is feature enabled in
     document for origin?</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="the-special-value">
+   <b><a href="#the-special-value">#the-special-value</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-special-value">4.8. Allowlists</a>
+    <li><a href="#ref-for-the-special-value①">8.3. Parse policy directive from
+    value and origin</a>
+    <li><a href="#ref-for-the-special-value②">8.5. Process feature policy
+    attributes</a> <a href="#ref-for-the-special-value③">(2)</a> <a href="#ref-for-the-special-value④">(3)</a> <a href="#ref-for-the-special-value⑤">(4)</a>
+    <li><a href="#ref-for-the-special-value⑥">8.6. Parse allow attribute</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="matches">


### PR DESCRIPTION
This defines allowlist to be either an ordered set of origins or the
special value *. Default allowlists are no longer defined to be
allowlists (since they contain items like 'self', which is not expanded
in the context of a default allowlist).

Algorithms handling allowlists are updated accordingly.

Fixes: #105, #106