### PR TITLE
Remove feature name

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -134,11 +134,11 @@ spec:fetch; type:dfn; text:value
     indicated, the term "feature" refers to <a>policy-controlled features</a>.
     Other specification, defining such features, should use the longer term to
     avoid any ambiguity.</div>
-    <p><a>Policy-controlled features</a> have a <dfn>feature name</dfn> keyword,
-    which is a token used in <a>policy directives</a>, and a <a>default
-    allowlist</a>, which defines whether the <a>policy-controlled feature</a>
-    is available to top-level documents, and how access to that feature is
-    inherited by cross-origin frames.</p>
+    <p><a>Policy-controlled features</a> are identified by tokens, which are
+    character strings used in <a>policy directives</a>.
+    <p>Each <a>policy-controlled feature</a> has a <a>default allowlist</a>,
+    which defines whether that feature is available to top-level documents, and
+    how access to that feature is inherited by cross-origin frames.</p>
     <p>A user agent has a set of <dfn>supported features</dfn>, which is the set
     of <a data-lt="policy-controlled feature">features</a> which it allows to be
     controlled through policies. User agents are not required to support every
@@ -225,17 +225,10 @@ spec:fetch; type:dfn; text:value
   <section>
     <h3 id="policy-directives">Policy directives</h3>
     <p>A <dfn data-lt="policy directive|policy directives">policy
-    directive</dfn> is an ordered map, mapping <a>feature names</a> to
-    corresponding <a>allowlists</a> of origins.</p>
+    directive</dfn> is an ordered map, mapping <a>policy-controlled features</a>
+    to corresponding <a>allowlists</a> of origins.</p>
     <p>A <a>policy directive</a> is represented in HTTP headers and HTML
     attributes as its ASCII serialization.</p>
-    <div class="note">
-      The allowed <a>feature names</a> are not defined by this specification.
-      A non-normative list of currently-defined features and their corresponding
-      names is maintained as a
-      <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
-      document</a> alongside this specification.
-    </div>
   </section>
   <section>
     <h3 id="allowlists">Allowlists</h3>
@@ -301,8 +294,8 @@ spec:fetch; type:dfn; text:value
     attributes as ASCII text [[!RFC8269]].</p>
     <pre class="abnf">
       <dfn>serialized-feature-policy</dfn> = <a>serialized-policy-directive</a> *(";" <a>serialized-policy-directive</a>)
-      <dfn>serialized-policy-directive</dfn> = <a>feature-name</a> RWS <a>allow-list</a>
-      <dfn>feature-name</dfn> = 1*( ALPHA / DIGIT / "-")
+      <dfn>serialized-policy-directive</dfn> = <a>feature-identifier</a> RWS <a>allow-list</a>
+      <dfn>feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
       <dfn>allow-list</dfn> = <a>allow-list-value</a> *(RWS <a>allow-list-value</a>)
       <dfn>allow-list-value</dfn> = <a>serialized-origin</a> / "*" / "'self'" / "'src'" / "'none'"
     </pre>
@@ -367,11 +360,11 @@ partial interface HTMLIFrameElement {
       {{requestFullscreen()}}.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>fullscreen</code>", then the
-      "<code>allowfullscreen</code> attribute must have no effect.</p>
-      <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
-      will result in adding an <a>allowlist</a> of <code>*</code> for the
-      "fullscreen" feature to the frame's <a>container policy</a>, when it is
-      constructed.</p>
+      "<code>allowfullscreen</code>" attribute must have no effect.</p>
+      <p>Otherwise, the presence of an "<code>allowfullscreen</code>" attribute
+      on an iframe will result in adding an <a>allowlist</a> of <code>*</code>
+      for the "<code>fullscreen</code>" feature to the frame's <a>container
+      policy</a>, when it is constructed.</p>
       <div class="note">
         This is different from the behaviour of <code>&lt;iframe
         allow="fullscreen"&gt;</code>, and is for compatibility with existing
@@ -387,11 +380,11 @@ partial interface HTMLIFrameElement {
       access to [=Payment interface=].</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>payment</code>", then the
-      "<code>allowpaymentrequest</code> attribute must have no effect.</p>
-      <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
-      iframe will result in adding an <a>allowlist</a> of <code>*</code> for
-      the "payment" feature to the frame's <a>container policy</a>, when it is
-      constructed.</p>
+      "<code>allowpaymentrequest</code>" attribute must have no effect.</p>
+      <p>Otherwise, the presence of an "<code>allowpaymentrequest</code>"
+      attribute on an iframe will result in adding an <a>allowlist</a> of
+      <code>*</code> for the "<code>payment</code>" feature to the frame's
+      <a>container policy</a>, when it is constructed.</p>
       <div class="note">
         This is different from the behaviour of <code>&lt;iframe
         allow="payment"&gt;</code>, and is for compatibility with existing uses
@@ -407,11 +400,12 @@ partial interface HTMLIFrameElement {
       access to [=Payment interface=].</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>payment</code>", then the
-      "<code>allowusermedia</code> attribute must have no effect.</p>
-      <p>Otherwise, the presence of an "allowusermedia" attribute on an
-      iframe will result in adding an <a>allowlist</a> of <code>*</code> for
-      each of the "camera" and "microphone" features to the frame's <a>container
-      policy</a>, when it is constructed.</p>
+      "<code>allowusermedia</code>" attribute must have no effect.</p>
+      <p>Otherwise, the presence of an "<code>allowusermedia</code>" attribute
+      on an iframe will result in adding an <a>allowlist</a> of <code>*</code>
+      for each of the "<code>camera</code>" and "<code>microphone</code>"
+      features to the frame's <a>container policy</a>, when it is
+      constructed.</p>
       <div class="note">
         This is different from the behaviour of <code>&lt;iframe
         allow="camera; microphone"&gt;</code>, and is for compatibility with
@@ -464,17 +458,16 @@ partial interface HTMLIFrameElement {
 	</p>
 
         <p>To determine whether a {{Document}} object <var>document</var>
-        is <dfn>allowed to use</dfn> the policy-controlled-feature named
-        <var>feature name</var>, run these steps:</p>
+        is <dfn>allowed to use</dfn> the policy-controlled-feature
+        <var>feature</var>, run these steps:</p>
         <ol>
          <li><p>If <var>document</var> has no [=browsing context=], then return
 	 false.</p></li>
          <li><p>If <var>document</var>'s [=browsing context=]'s [=active
 	 document=] is not <var>document</var>, then return false.</p></li>
          <li><p>If <var>document</var>'s <a>feature policy</a> <a
-	 href="#is-feature-enabled">enables the feature indicated by
-	 <var>feature name</var> for the origin of <var>document</var></a>, then
-	 return true.<p></li>
+	 href="#is-feature-enabled">enables <var>feature</var> for the origin of
+         <var>document</var></a>, then return true.<p></li>
          <li><p>Return false.</p></li>
         </ol>
       </li>
@@ -500,8 +493,8 @@ partial interface HTMLIFrameElement {
       <p>The <{iframe/allowpaymentrequest}> attribute is a boolean attribute.
       When specified, it indicates that {{Document}} objects in the <{iframe}>
       element's [=browsing context=] should be initialized with a <a>feature
-      policy</a> which allows the <code>PaymentRequest</code> feature to be used
-      to make payment rquests from any origin. This is enforced by the <a
+      policy</a> which allows the <code>payment</code> feature to be used
+      to make payment requests from any origin. This is enforced by the <a
       href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the
       <code>PaymentRequest</code> interface if the <{iframe}> element's [=node
@@ -509,8 +502,8 @@ partial interface HTMLIFrameElement {
       <p>The <{iframe/allowusermedia}> attribute is a boolean attribute. When
       specified, it indicates that {{Document}} objects in the <{iframe}>
       element's [=browsing context=] should be initialized with a <a>feature
-      policy</a> which allows the <code>Camera</code> and
-      <code>Microphone</code> features to be used to call
+      policy</a> which allows the <code>camera</code> and
+      <code>microphone</code> features to be used to call
       <code>getUserMedia()</code> from any origin. This is enforced by the <a
       href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the
@@ -588,10 +581,10 @@ partial interface HTMLIFrameElement {
 	  <li>If <var>tokens</var> is an empty list, then continue.</li>
           <li>Let <var>feature-name</var> be the first element of
 	  <var>tokens</var>.</li>
-          <li>If <var>feature-name</var> is not equal to the name of any
-	  recognized <a>policy-controlled feature</a>, then continue.</li>
+          <li>If <var>feature-name</var> does not identify any recognized
+          <a>policy-controlled feature</a>, then continue.</li>
           <li>Let <var>feature</var> be the <a>policy-controlled feature</a>
-	  named by <var>feature-name</var>.</li>
+	  identified by <var>feature-name</var>.</li>
           <li>Let <var>targetlist</var> be the remaining elements, if any, of
 	  <var>tokens</var>.
           <li>Let <var>allowlist</var> be a new <a>allowlist</a>.
@@ -727,10 +720,10 @@ partial interface HTMLIFrameElement {
 	  <li>If <var>tokens</var> is an empty list, then continue.</li>
           <li>Let <var>feature-name</var> be the first element of
 	  <var>tokens</var>.</li>
-          <li>If <var>feature-name</var> is not equal to the name of any
-	  recognized <a>policy-controlled feature</a>, then continue.</li>
+          <li>If <var>feature-name</var> does not identify any recognized
+          <a>policy-controlled feature</a>, then continue.</li>
           <li>Let <var>feature</var> be the <a>policy-controlled feature</a>
-	  named by <var>feature-name</var>.</li>
+	  identified by <var>feature-name</var>.</li>
           <li>Let <var>targetlist</var> be the remaining elements, if any, of
 	  <var>tokens</var>.
           <li>Let <var>allowlist</var> be a new <a>allowlist</a>.
@@ -867,7 +860,7 @@ partial interface HTMLIFrameElement {
   <section>
     <h3 id="is-feature-enabled">Is <var>feature</var> enabled in
     <var>document</var> for <var>origin</var>?</h3>
-    <p>Given a string (<var>feature</var>) and a Document object
+    <p>Given a feature (<var>feature</var>), a Document object
     (<var>document</var>), and an [=origin=] (<var>origin</var>), this algorithm
     returns "<code>Disabled</code>" if <var>feature</var> should be considered
     disabled, and "<code>Enabled</code>" otherwise.</p>

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 24e86bd5bd6c90b3d57bf1ee168df70f4e11d8c4" name="generator">
   <link href="https://wicg.github.io/feature-policy/" rel="canonical">
-  <meta content="660ebbf447eed714780e610b714afc044f83d02e" name="document-revision">
+  <meta content="ccbd6b3734514c5696a99af229a5a0342d7a635d" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1651,10 +1651,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     indicated, the term "feature" refers to <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature">policy-controlled features</a>.
     Other specification, defining such features, should use the longer term to
     avoid any ambiguity.</div>
-     <p><a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①">Policy-controlled features</a> have a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-name">feature name</dfn> keyword,
-    which is a token used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive">policy directives</a>, and a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist">default
-    allowlist</a>, which defines whether the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> is available to top-level documents, and how access to that feature is
-    inherited by cross-origin frames.</p>
+     <p><a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①">Policy-controlled features</a> are identified by tokens, which are
+    character strings used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive">policy directives</a>. </p>
+     <p>Each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> has a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist">default allowlist</a>,
+    which defines whether that feature is available to top-level documents, and
+    how access to that feature is inherited by cross-origin frames.</p>
      <p>A user agent has a set of <dfn data-dfn-type="dfn" data-noexport="" id="supported-features">supported features<a class="self-link" href="#supported-features"></a></dfn>, which is the set
     of <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature③">features</a> which it allows to be
     controlled through policies. User agents are not required to support every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature④">feature</a>.</p>
@@ -1717,14 +1718,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="4.7" id="policy-directives"><span class="secno">4.7. </span><span class="content">Policy directives</span><a class="self-link" href="#policy-directives"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="policy directive|policy directives" data-noexport="" id="policy-directive">policy
-    directive</dfn> is an ordered map, mapping <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name">feature names</a> to
-    corresponding <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist②">allowlists</a> of origins.</p>
+    directive</dfn> is an ordered map, mapping <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①①">policy-controlled features</a> to corresponding <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist②">allowlists</a> of origins.</p>
      <p>A <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive③">policy directive</a> is represented in HTTP headers and HTML
     attributes as its ASCII serialization.</p>
-     <div class="note" role="note"> The allowed <a data-link-type="dfn" href="#feature-name" id="ref-for-feature-name②">feature names</a> are not defined by this specification.
-      A non-normative list of currently-defined features and their corresponding
-      names is maintained as a <a href="https://github.com/WICG/feature-policy/blob/gh-pages/features.md">companion
-      document</a> alongside this specification. </div>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.8" id="allowlists"><span class="secno">4.8. </span><span class="content">Allowlists</span><a class="self-link" href="#allowlists"></a></h3>
@@ -1754,11 +1750,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="4.9" id="default-allowlists"><span class="secno">4.9. </span><span class="content">Default Allowlists</span><a class="self-link" href="#default-allowlists"></a></h3>
-     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①①">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> controls the origins which are allowed to access
+     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①②">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="default allowlist|default allowlists" data-noexport="" id="default-allowlist">default allowlist</dfn>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> controls the origins which are allowed to access
     the feature when used in a top-level document with no declared policy, and
     also determines whether access to the feature is automatically delegated to
     child documents.</p>
-     <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist②">default allowlist</a> for a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①②">feature</a> is one of these values:</p>
+     <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist②">default allowlist</a> for a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①③">feature</a> is one of these values:</p>
      <dl>
       <dt><code>*</code>
       <dd>The feature is allowed at the top level by default, and when allowed,
@@ -1781,8 +1777,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <p><a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive④">Policy Directives</a> are represented in HTTP headers and in HTML
     attributes as ASCII text <a data-link-type="biblio" href="#biblio-rfc8269">[RFC8269]</a>.</p>
 <pre class="abnf"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="serialized-feature-policy">serialized-feature-policy</dfn> = <a data-link-type="dfn" href="#serialized-policy-directive" id="ref-for-serialized-policy-directive">serialized-policy-directive</a> *(";" <a data-link-type="dfn" href="#serialized-policy-directive" id="ref-for-serialized-policy-directive①">serialized-policy-directive</a>)
-<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="serialized-policy-directive">serialized-policy-directive</dfn> = <a data-link-type="dfn" href="#feature-name①" id="ref-for-feature-name①">feature-name</a> RWS <a data-link-type="dfn" href="#allow-list" id="ref-for-allow-list">allow-list</a>
-<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-name①">feature-name</dfn> = 1*( ALPHA / DIGIT / "-")
+<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="serialized-policy-directive">serialized-policy-directive</dfn> = <a data-link-type="dfn" href="#feature-identifier" id="ref-for-feature-identifier">feature-identifier</a> RWS <a data-link-type="dfn" href="#allow-list" id="ref-for-allow-list">allow-list</a>
+<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-identifier">feature-identifier</dfn> = 1*( ALPHA / DIGIT / "-")
 <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allow-list">allow-list</dfn> = <a data-link-type="dfn" href="#allow-list-value" id="ref-for-allow-list-value">allow-list-value</a> *(RWS <a data-link-type="dfn" href="#allow-list-value" id="ref-for-allow-list-value①">allow-list-value</a>)
 <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allow-list-value">allow-list-value</dfn> = <a data-link-type="dfn">serialized-origin</a> / "*" / "'self'" / "'src'" / "'none'"
 </pre>
@@ -1821,12 +1817,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     that case, the default value for the allowlist is <code>'src'</code>, which
     represents the origin of the URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src" id="ref-for-attr-iframe-src">src</a></code> attribute. </p>
      <p>When not empty, the "<code>allow</code>" attribute will result in adding
-    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑦">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①③">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy④">container policy</a>, when it is contructed.</p>
+    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑦">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①④">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy④">container policy</a>, when it is contructed.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.3" id="legacy-attributes"><span class="secno">6.3. </span><span class="content">Additional attributes to support legacy
     features</span><a class="self-link" href="#legacy-attributes"></a></h3>
-     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①④">features</a> controlled by
+     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑤">features</a> controlled by
     Feature Policy have existing iframe attributes defined. This specification
     redefines these attributes to act as declared policies for the iframe
     element.</p>
@@ -1835,11 +1831,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <p>The "<code>allowfullscreen</code>" iframe attribute controls access to <code class="idl"><a data-link-type="idl" href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen" id="ref-for-dom-element-requestfullscreen">requestFullscreen()</a></code>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>fullscreen</code>", then the
-      "<code>allowfullscreen</code> attribute must have no effect.</p>
-      <p>Otherwise, the presence of an "allowfullscreen" attribute on an iframe
-      will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑧">allowlist</a> of <code>*</code> for the
-      "fullscreen" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑤">container policy</a>, when it is
-      constructed.</p>
+      "<code>allowfullscreen</code>" attribute must have no effect.</p>
+      <p>Otherwise, the presence of an "<code>allowfullscreen</code>" attribute
+      on an iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑧">allowlist</a> of <code>*</code> for the "<code>fullscreen</code>" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑤">container
+      policy</a>, when it is constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
         allow="fullscreen"></code>, and is for compatibility with existing
         uses of <code>allowfullscreen</code>. If <code>allow="fullscreen"</code> and <code>allowfullscreen</code> are
@@ -1852,11 +1847,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       access to <a data-link-type="dfn">Payment interface</a>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>payment</code>", then the
-      "<code>allowpaymentrequest</code> attribute must have no effect.</p>
-      <p>Otherwise, the presence of an "allowpaymentrequest" attribute on an
-      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑨">allowlist</a> of <code>*</code> for
-      the "payment" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑥">container policy</a>, when it is
-      constructed.</p>
+      "<code>allowpaymentrequest</code>" attribute must have no effect.</p>
+      <p>Otherwise, the presence of an "<code>allowpaymentrequest</code>"
+      attribute on an iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑨">allowlist</a> of <code>*</code> for the "<code>payment</code>" feature to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑥">container policy</a>, when it is constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
         allow="payment"></code>, and is for compatibility with existing uses
         of <code>allowpaymentrequest</code>. If <code>allow="payment"</code> and <code>allowpaymentrequest</code> are both present on an iframe
@@ -1868,11 +1861,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       access to <a data-link-type="dfn">Payment interface</a>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>payment</code>", then the
-      "<code>allowusermedia</code> attribute must have no effect.</p>
-      <p>Otherwise, the presence of an "allowusermedia" attribute on an
-      iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①⓪">allowlist</a> of <code>*</code> for
-      each of the "camera" and "microphone" features to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑦">container
-      policy</a>, when it is constructed.</p>
+      "<code>allowusermedia</code>" attribute must have no effect.</p>
+      <p>Otherwise, the presence of an "<code>allowusermedia</code>" attribute
+      on an iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①⓪">allowlist</a> of <code>*</code> for each of the "<code>camera</code>" and "<code>microphone</code>"
+      features to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑦">container policy</a>, when it is
+      constructed.</p>
       <div class="note" role="note"> This is different from the behaviour of <code>&lt;iframe
         allow="camera; microphone"></code>, and is for compatibility with
 	existing uses of <code>allowusermedia</code>. If <code>allow="camera;
@@ -1910,7 +1903,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document" id="ref-for-dom-document⑨">Document</a></code> by setting it as the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document" id="ref-for-dom-document①⓪">Document</a></code>'s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑤">Feature Policy</a>. 
       <li>
        <p>The "<a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use">allowed to use</a>" algorithm is replaced with the following: </p>
-       <p>To determine whether a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document" id="ref-for-dom-document①①">Document</a></code> object <var>document</var> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed-to-use">allowed to use</dfn> the policy-controlled-feature named <var>feature name</var>, run these steps:</p>
+       <p>To determine whether a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document" id="ref-for-dom-document①①">Document</a></code> object <var>document</var> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed-to-use">allowed to use</dfn> the policy-controlled-feature <var>feature</var>, run these steps:</p>
        <ol>
         <li>
          <p>If <var>document</var> has no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a>, then return
@@ -1919,8 +1912,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
          <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active
 	 document</a> is not <var>document</var>, then return false.</p>
         <li>
-         <p>If <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑥">feature policy</a> <a href="#is-feature-enabled">enables the feature indicated by <var>feature name</var> for the origin of <var>document</var></a>, then
-	 return true.</p>
+         <p>If <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑥">feature policy</a> <a href="#is-feature-enabled">enables <var>feature</var> for the origin of <var>document</var></a>, then return true.</p>
          <p></p>
         <li>
          <p>Return false.</p>
@@ -1942,13 +1934,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use①">allowed to use</a> <code>fullscreen</code>. </p>
        <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowpaymentrequest" id="ref-for-attr-iframe-allowpaymentrequest①">allowpaymentrequest</a></code> attribute is a boolean attribute.
       When specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document" id="ref-for-dom-document①③">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑥">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑨">feature
-      policy</a> which allows the <code>PaymentRequest</code> feature to be used
-      to make payment rquests from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
+      policy</a> which allows the <code>payment</code> feature to be used
+      to make payment requests from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the <code>PaymentRequest</code> interface if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑦">iframe</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document①">node
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use②">allowed to use</a> the feature. </p>
        <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowusermedia" id="ref-for-attr-iframe-allowusermedia①">allowusermedia</a></code> attribute is a boolean attribute. When
       specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-document" id="ref-for-dom-document①④">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑧">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⓪">feature
-      policy</a> which allows the <code>Camera</code> and <code>Microphone</code> features to be used to call <code>getUserMedia()</code> from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
+      policy</a> which allows the <code>camera</code> and <code>microphone</code> features to be used to call <code>getUserMedia()</code> from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the <code>getUserMedia()</code> interface if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑨">iframe</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document②">node
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use③">allowed to use</a> the feature. </p>
       <li>The <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#set-the-allow*-flags">set
@@ -2005,9 +1997,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>Let <var>tokens</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace">splitting <var>serialized-declaration</var> on ASCII whitespace.</a>
         <li>If <var>tokens</var> is an empty list, then continue.
         <li>Let <var>feature-name</var> be the first element of <var>tokens</var>.
-        <li>If <var>feature-name</var> is not equal to the name of any
-	  recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑤">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑥">policy-controlled feature</a> named by <var>feature-name</var>.
+        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑥">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑦">policy-controlled feature</a> identified by <var>feature-name</var>.
         <li>Let <var>targetlist</var> be the remaining elements, if any, of <var>tokens</var>. 
         <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①①">allowlist</a>. 
         <li>If any element of <var>targetlist</var> is the string
@@ -2115,9 +2106,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>Let <var>tokens</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace①">splitting <var>serialized-declaration</var> on ASCII whitespace.</a>
         <li>If <var>tokens</var> is an empty list, then continue.
         <li>Let <var>feature-name</var> be the first element of <var>tokens</var>.
-        <li>If <var>feature-name</var> is not equal to the name of any
-	  recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑦">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑧">policy-controlled feature</a> named by <var>feature-name</var>.
+        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑧">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑨">policy-controlled feature</a> identified by <var>feature-name</var>.
         <li>Let <var>targetlist</var> be the remaining elements, if any, of <var>tokens</var>. 
         <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①②">allowlist</a>. 
         <li>If any element of <var>targetlist</var> is the string
@@ -2219,7 +2209,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="8.10" id="is-feature-enabled"><span class="secno">8.10. </span><span class="content">Is <var>feature</var> enabled in <var>document</var> for <var>origin</var>?</span><a class="self-link" href="#is-feature-enabled"></a></h3>
-     <p>Given a string (<var>feature</var>) and a Document object
+     <p>Given a feature (<var>feature</var>), a Document object
     (<var>document</var>), and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin⑤">origin</a> (<var>origin</var>), this algorithm
     returns "<code>Disabled</code>" if <var>feature</var> should be considered
     disabled, and "<code>Enabled</code>" otherwise.</p>
@@ -2412,8 +2402,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <ul class="index">
    <li><a href="#dom-htmliframeelement-allow">allow</a><span>, in §6.2</span>
    <li><a href="#allowed-to-use">allowed to use</a><span>, in §7.1</span>
-   <li><a href="#allow-list">allow-list</a><span>, in §5.1</span>
    <li><a href="#allowlist">allowlist</a><span>, in §4.8</span>
+   <li><a href="#allow-list">allow-list</a><span>, in §5.1</span>
    <li><a href="#allowlist">allowlists</a><span>, in §4.8</span>
    <li><a href="#allow-list-value">allow-list-value</a><span>, in §5.1</span>
    <li><a href="#container-policy">container policy</a><span>, in §4.6</span>
@@ -2423,8 +2413,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#default-allowlist">default allowlists</a><span>, in §4.9</span>
    <li><a href="#empty-feature-policy">empty feature policy</a><span>, in §4.2</span>
    <li><a href="#enforce">enforce</a><span>, in §7.1</span>
-   <li><a href="#feature-name">feature name</a><span>, in §4.1</span>
-   <li><a href="#feature-name①">feature-name</a><span>, in §5.1</span>
+   <li><a href="#feature-identifier">feature-identifier</a><span>, in §5.1</span>
    <li><a href="#feature-policy">feature policy</a><span>, in §4.2</span>
    <li><a href="#feature-policy-aware">feature-policy-aware</a><span>, in §4.4</span>
    <li><a href="#feature-policy-header">feature-policy-header</a><span>, in §6.1</span>
@@ -2560,20 +2549,15 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-policy-controlled-feature⑥">4.2. Policies</a>
     <li><a href="#ref-for-policy-controlled-feature⑦">4.3. Inherited policies</a> <a href="#ref-for-policy-controlled-feature⑧">(2)</a> <a href="#ref-for-policy-controlled-feature⑨">(3)</a>
     <li><a href="#ref-for-policy-controlled-feature①⓪">4.4. Declared policies</a>
-    <li><a href="#ref-for-policy-controlled-feature①①">4.9. Default Allowlists</a> <a href="#ref-for-policy-controlled-feature①②">(2)</a>
-    <li><a href="#ref-for-policy-controlled-feature①③">6.2. The allow attribute of the
+    <li><a href="#ref-for-policy-controlled-feature①①">4.7. Policy directives</a>
+    <li><a href="#ref-for-policy-controlled-feature①②">4.9. Default Allowlists</a> <a href="#ref-for-policy-controlled-feature①③">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①④">6.2. The allow attribute of the
     iframe element</a>
-    <li><a href="#ref-for-policy-controlled-feature①④">6.3. Additional attributes to support legacy
+    <li><a href="#ref-for-policy-controlled-feature①⑤">6.3. Additional attributes to support legacy
     features</a>
-    <li><a href="#ref-for-policy-controlled-feature①⑤">8.3. Parse policy directive from
-    value and origin</a> <a href="#ref-for-policy-controlled-feature①⑥">(2)</a>
-    <li><a href="#ref-for-policy-controlled-feature①⑦">8.6. Parse allow attribute</a> <a href="#ref-for-policy-controlled-feature①⑧">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="feature-name">
-   <b><a href="#feature-name">#feature-name</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-feature-name">4.7. Policy directives</a> <a href="#ref-for-feature-name②">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①⑥">8.3. Parse policy directive from
+    value and origin</a> <a href="#ref-for-policy-controlled-feature①⑦">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①⑧">8.6. Parse allow attribute</a> <a href="#ref-for-policy-controlled-feature①⑨">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="feature-policy">
@@ -2738,10 +2722,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     iframe element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature-name①">
-   <b><a href="#feature-name①">#feature-name①</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="feature-identifier">
+   <b><a href="#feature-identifier">#feature-identifier</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-feature-name①">5.1. ASCII serialization</a>
+    <li><a href="#ref-for-feature-identifier">5.1. ASCII serialization</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="allow-list">

--- a/integration.md
+++ b/integration.md
@@ -18,15 +18,23 @@ policy-controlled feature:
 > Example:
 >
 >### Section N: Feature Policy Integration
-> The Sample API is a *policy-controlled feature*, as defined by
-> [Feature Policy](https://wicg.github.io/feature-policy/).
+> The Sample API defines a [*policy-controlled feature*](https://wicg.github.io/feature-policy/#policy-controlled-feature)
+> identified by the string "`sample`". Its [default allowlist](https://wicg.github.io/feature-policy/#default-allowlist)
+> is `'self'` \[[FEATURE-POLICY](https://wicg.github.io/feature-policy/)\].
+
+The specification can then refer to this feature, and test whether it is enabled
+or not in a specific document, with text similar to this:
+
+> Example:
 >
-> * The **feature name** for the Sample API is "`sample`".
-> * The **default allowlist** for the Sample API is `'self'`.
->
-> When disabled in a document, the `getArbitrarySamples()` method MUST return a
-> promise which rejects with a `SecurityError` DOMException object as its
-> parameter.
+> If the [responsible document](https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document)
+> is not [allowed to use](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use)
+> the `sample` feature, then throw a `SecurityError`
+> [DOMException](https://heycam.github.io/webidl/#dfn-DOMException) and abort these steps.
+
+(This is an example only. The actual behavior of any algorithm when a
+policy-controlled feature is disabled is left up to the specification which
+defines that feature.)
 
 ## Choosing a default allowlist
 


### PR DESCRIPTION
Removes the extra 'feature name' concept from the spec, and just declares the existing "feature-name" string to be an identifying token for a feature. This should simplify spec integration and remove the need for authors to define two different names for a policy-controlled feature.