### PR TITLE
Break the circular definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -139,8 +139,7 @@ spec:fetch; type:dfn; text:value
     avoid any ambiguity.</div>
     <div class="issue">This spec currently only deals with features defined in
     Documents. We should figure out how to word this to include the possibility
-    of features in Workers as well, and for feature policies to be attached to
-    Workers.</div>
+    of features and feature policies in Workers and Worklets as well.</div>
     <p><a>Policy-controlled features</a> are identified by tokens, which are
     character strings used in <a>policy directives</a>.
     <p>Each <a>policy-controlled feature</a> has a <a>default allowlist</a>,

--- a/index.bs
+++ b/index.bs
@@ -130,8 +130,8 @@ spec:fetch; type:dfn; text:value
     <h3 id="features">Policy-controlled Features</h3>
     <p>A <dfn export
     data-lt="policy-controlled feature">policy-controlled feature</dfn> is an
-    API or behaviour which can be enabled or disabled in a document by referring
-    to it in a <a>feature policy</a>.
+    API or behaviour which can be enabled or disabled in a browsing context by
+    referring to it in a <a>feature policy</a>.
     <div class="note">For brevity, policy-controlled features will often be
     referred to in this document simply as "Features". Unless otherwise
     indicated, the term "feature" refers to <a>policy-controlled features</a>.
@@ -140,8 +140,9 @@ spec:fetch; type:dfn; text:value
     <p><a>Policy-controlled features</a> are identified by tokens, which are
     character strings used in <a>policy directives</a>.
     <p>Each <a>policy-controlled feature</a> has a <a>default allowlist</a>,
-    which defines whether that feature is available to top-level documents, and
-    how access to that feature is inherited by cross-origin frames.</p>
+    which defines whether that feature is available in documents in top-level
+    browsing contexts, and how access to that feature is inherited in nested
+    browsing contexts.</p>
     <p>A user agent has a set of <dfn>supported features</dfn>, which is the set
     of <a data-lt="policy-controlled feature">features</a> which it allows to be
     controlled through policies. User agents are not required to support every
@@ -156,7 +157,7 @@ spec:fetch; type:dfn; text:value
   </section>
   <section>
     <h3 id="policies">Policies</h3>
-    <p>A {{Document}} has a <dfn>feature policy</dfn>, which consists of:</p>
+    <p>A <dfn>feature policy</dfn> is a struct with the following items:</p>
     <ul>
       <li>A set of <a data-lt="inherited policy set">inherited policies</a>.
       </li>
@@ -169,6 +170,14 @@ spec:fetch; type:dfn; text:value
   </section>
   <section>
     <h3 id="inherited-policies">Inherited policies</h3>
+    <p>An <dfn data-lt="inherited policy|inherited policies">inherited
+    policy</dfn> is either 'Enabled' or 'Disabled'.</p>
+    <p>An <dfn>inherited policy set</dfn> is an ordered map from
+    <a data-lt="policy-controlled feature">features</a> to <a>inherited
+    policies</a>. After a <a>feature policy</a> has been initialized, its
+    <a>inherited policy set</a> will contain an <a>inherited policy</a> for each
+    <a>supported feature</a>.</p>
+    <div class="note">
     <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
     for each <a>policy-controlled feature</a>. This inherited policy set
@@ -181,12 +190,7 @@ spec:fetch; type:dfn; text:value
     set is based on the parent document's feature policy, as well as any
     <a href="#iframe-allow-attribute">allow attributes</a> defined on the
     browsing context container.</p>
-    <p>An <dfn data-lt="inherited policy|inherited policies">inherited
-    policy</dfn> declares a <a data-lt="policy-controlled feature">feature</a>
-    as Enabled or Disabled.</p>
-    <p>An <dfn>inherited policy set</dfn> for a {{Document}} is the set of
-    <a>inherited policies</a> for each <a
-    data-lt="policy-controlled feature">feature</a> available in that scope.</p>
+    </div>
   </section>
   <section>
     <h3 id="declared-policies">Declared policies</h3>
@@ -194,15 +198,11 @@ spec:fetch; type:dfn; text:value
     policy</dfn> is an ordered map from
     <a data-lt="policy-controlled feature">features</a> to <a>allowlists</a>.
     </p>
-    <p>A {{Document}} is considered <dfn>feature-policy-aware</dfn> if it has a
-    <a>declared policy</a> which is not empty.</p>
-    <p>A {{Document}} which is not <a>feature-policy-aware</a> is considered
-    <dfn>feature-policy-oblivious</dfn>.</p>
   </section>
   <section>
     <h3 id="header-policies">Header policies</h3>
     <p>A <dfn>header policy</dfn> is a list of <a>policy directives</a>
-    delivered via an HTTP header with the document. This forms the document's
+    delivered via an HTTP header with a document. This forms the document's
     <a>feature policy</a>'s <a>declared policy</a>.</p>
   </section>
   <section>
@@ -268,24 +268,26 @@ spec:fetch; type:dfn; text:value
     <h3 id="default-allowlists">Default Allowlists</h3>
     <p>Every <a>policy-controlled feature</a> has a <dfn export lt=
     "default allowlist|default allowlists">default allowlist</dfn>. The
-    <a>default allowlist</a> controls the origins which are allowed to access
-    the feature when used in a top-level document with no declared policy, and
-    also determines whether access to the feature is automatically delegated to
-    child documents.</p>
+    <a>default allowlist</a> determines whether the feature is allowed in a
+    document with no declared policy in a top-level browsing context, and also
+    whether access to the feature is automatically delegated to documents in
+    nested browsing contexts.</p>
     <p>The <a>default allowlist</a> for a <a
     data-lt="policy-controlled feature">feature</a> is one of these values:</p>
     <dl>
       <dt><code>*</code></dt>
-      <dd>The feature is allowed at the top level by default, and when allowed,
-      is allowed by default to documents in child frames.</dd>
+      <dd>The feature is allowed in documents in top-level browsing contexts by
+      default, and when allowed, is allowed by default to documents in nested
+      browsing contexts.</dd>
       <dt><code>'self'</code></dt>
-      <dd>The feature is allowed at the top level by default, and when allowed,
-      is allowed by default to same-origin domain documents in child frames,
-      but is disallowed by default in cross-origin documents in child
-      frames.</dd>
+      <dd>The feature is allowed in documents in top-level browsing contexts by
+      default, and when allowed, is allowed by default to same-origin domain
+      documents in nested browsing contexts, but is disallowed by default in
+      cross-origin documents in nested browsing contexts.</dd>
       <dt>'none'</dt>
-      <dd>The feature is disallowed at the top level by default, and is also
-      disallowed by default to documents in child frames.</dd>
+      <dd>The feature is disallowed in documents in top-level browsing contexts
+      by default, and is also disallowed by default to documents in nested
+      browsing contexts.</dd>
     </dl>
   </section>
 </section>

--- a/index.bs
+++ b/index.bs
@@ -130,13 +130,17 @@ spec:fetch; type:dfn; text:value
     <h3 id="features">Policy-controlled Features</h3>
     <p>A <dfn export
     data-lt="policy-controlled feature">policy-controlled feature</dfn> is an
-    API or behaviour which can be enabled or disabled in a browsing context by
-    referring to it in a <a>feature policy</a>.
+    API or behaviour which can be enabled or disabled in a document by referring
+    to it in a <a>feature policy</a>.
     <div class="note">For brevity, policy-controlled features will often be
     referred to in this document simply as "Features". Unless otherwise
     indicated, the term "feature" refers to <a>policy-controlled features</a>.
     Other specifications, defining such features, should use the longer term to
     avoid any ambiguity.</div>
+    <div class="issue">This spec currently only deals with features defined in
+    Documents. We should figure out how to word this to include the possibility
+    of features in Workers as well, and for feature policies to be attached to
+    Workers.</div>
     <p><a>Policy-controlled features</a> are identified by tokens, which are
     character strings used in <a>policy directives</a>.
     <p>Each <a>policy-controlled feature</a> has a <a>default allowlist</a>,

--- a/index.bs
+++ b/index.bs
@@ -163,35 +163,36 @@ spec:fetch; type:dfn; text:value
     <h3 id="policies">Policies</h3>
     <p>A <dfn>feature policy</dfn> is a struct with the following items:</p>
     <ul>
-      <li>A set of <a data-lt="inherited policy set">inherited policies</a>.
+      <li>An <a data-lt="inherited policy">inherited policy</a>.
       </li>
       <li>A <a data-lt="declared policy">declared policy</a>.
       </li>
     </ul>
-    <p>An <dfn>empty feature policy</dfn> has an <a>inherited policy set</a>
+    <p>An <dfn>empty feature policy</dfn> has an <a>inherited policy</a>
     which contains 'Enabled' for every <a>policy-controlled feature</a>
     available, and a <a>declared policy</a> which is an empty map.</p>
   </section>
   <section>
     <h3 id="inherited-policies">Inherited policies</h3>
     <p>An <dfn data-lt="inherited policy|inherited policies">inherited
-    policy</dfn> is either 'Enabled' or 'Disabled'.</p>
-    <p>An <dfn>inherited policy set</dfn> is an ordered map from
-    <a data-lt="policy-controlled feature">features</a> to <a>inherited
-    policies</a>. After a <a>feature policy</a> has been initialized, its
-    <a>inherited policy set</a> will contain an <a>inherited policy</a> for each
-    <a>supported feature</a>.</p>
+    policy</dfn> is an ordered map from <a
+    data-lt="policy-controlled feature">features</a> to either 'Enabled' or
+    'Disabled'.</p>
+    <p>The <dfn>inherited policy for a feature</dfn> <var>feature</var> is the
+    value in the <a>inherited policy</a> whose key is <var>feature</var>. After
+    a <a>feature policy</a> has been initialized, its <a>inherited policy</a>
+    will contain an value for each <a>supported feature</a>.</p>
     <div class="note">
     <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
-    for each <a>policy-controlled feature</a>. This inherited policy set
-    determines the initial state (enabled or disabled) of each feature, and
-    whether it can be controlled by a <a>declared policy</a> in the document.
+    for each <a>policy-controlled feature</a>. This inherited policy determines
+    the initial state (enabled or disabled) of each feature, and whether it can
+    be controlled by a <a>declared policy</a> in the document.
     </p>
     <p>In a {{Document}} in a [=top-level browsing context=], the inherited
-    feature set is based on defined defaults for each feature.</p>
-    <p>In a {{Document}} in a [=nested browsing context=], the inherited feature
-    set is based on the parent document's feature policy, as well as any
+    policy is based on defined defaults for each feature.</p>
+    <p>In a {{Document}} in a [=nested browsing context=], the inherited policy
+    is based on the parent document's feature policy, as well as any
     <a href="#iframe-allow-attribute">allow attributes</a> defined on the
     browsing context container.</p>
     </div>
@@ -783,21 +784,21 @@ partial interface HTMLIFrameElement {
     <p>Given a Document object (<var>document</var>), this algorithm
     initialises <var>document</var>'s <a>Feature Policy</a></p>
     <ol>
-      <li>Let <var>inherited policies</var> be a new ordered map.</li>
-      <li>Let <var>declared policies</var> be a new ordered map.</li>
+      <li>Let <var>inherited policy</var> be a new ordered map.</li>
+      <li>Let <var>declared policy</var> be a new ordered map.</li>
       <li>For each <var>feature</var> supported,
         <ol>
           <li>Let <var>isInherited</var> be the result of running <a href=
           "#define-inherited-policy"></a> on <var>feature</var> and
           <var>document</var>'s browsing context.
           </li>
-          <li>Set <var>inherited policies</var>[<var>feature</var>] to
+          <li>Set <var>inherited policy</var>[<var>feature</var>] to
             <var>isInherited</var>.</li>
         </ol>
       </li>
       <li>Let <var>policy</var> be a new <a>feature policy</a>, with inherited
-      policy set <var>inherited policies</var> and declared policy set
-      <var>declared policies</var>.
+      policy <var>inherited policy</var> and declared policy <var>declared
+      policy</var>.
       </li>
       <li>
         <a>Enforce</a> the policy <var>policy</var> on <var>document</var>.
@@ -812,22 +813,22 @@ partial interface HTMLIFrameElement {
     <a>Feature Policy</a></p>
     <ol>
       <li>Initialize <var>document</var>'s Feature Policy</li>
-      <li>Let <var>inherited policies</var> be <var>document</var>'s Feature
-      Policy's inherited policy set.</li>
-      <li>Let <var>declared policies</var> be a new ordered map.</li>
+      <li>Let <var>inherited policy</var> be <var>document</var>'s Feature
+      Policy's <a>inherited policy</a>.</li>
+      <li>Let <var>declared policy</var> be a new ordered map.</li>
       <li>Let <var>d</var> be the result of running <a
       href="#process-response-policy">Process response policy</a> on
       <var>response</var> and <var>document</var>'s origin.</li>
       <li>For each <var>feature</var> → <var>allowlist</var> of <var>d</var>:
         <ol>
-          <li>If <var>inherited policies</var>[<var>feature</var>] is true, then
-	  set <var>declared policies</var>[<var>feature</var>] to
+          <li>If <var>inherited policy</var>[<var>feature</var>] is true, then
+	  set <var>declared policy</var>[<var>feature</var>] to
 	  <var>allowlist</var>.</li>
         </ol>
       </li>
       <li>Let <var>policy</var> be a new <a>feature policy</a>, with inherited
-      policy set <var>inherited policies</var> and declared policy set
-      <var>declared policies</var>.
+      policy <var>inherited policy</var> and declared policy <var>declared
+      policy</var>.
       </li>
       <li>
         <a>Enforce</a> the policy <var>policy</var> on <var>document</var>.
@@ -837,7 +838,7 @@ partial interface HTMLIFrameElement {
   <section>
     <h3 id="define-inherited-policy">Define an inherited policy for
     <var>feature</var></h3>
-    <p>Given a string (<var>feature</var>) and a browsing context
+    <p>Given a feature (<var>feature</var>) and a browsing context
     (<var>context</var>), this algorithm returns the <a>inherited policy</a>
     for that feature.</p>
     <ol>
@@ -860,8 +861,8 @@ partial interface HTMLIFrameElement {
               <li>Otherwise return Disabled.</li>
             </ol>
           </li>
-          <li>Otherwise, if feature is enabled in <var>parent</var> for
-	  <var>origin</var>, return Enabled.
+          <li>Otherwise, if <var>feature</var> is enabled in <var>parent</var>
+	  for <var>origin</var>, return Enabled.
           </li>
           <li>Otherwise, return Disabled.</li>
         </ol>

--- a/index.bs
+++ b/index.bs
@@ -167,9 +167,9 @@ spec:fetch; type:dfn; text:value
       <li>A <a data-lt="declared policy">declared policy</a>.
       </li>
     </ul>
-    <p>An <dfn>empty feature policy</dfn> has an <a>inherited policy</a>
-    which contains 'Enabled' for every <a>policy-controlled feature</a>
-    available, and a <a>declared policy</a> which is an empty map.</p>
+    <p>An <dfn>empty feature policy</dfn> is a <a>feature policy</a> that has
+    an <a>inherited policy</a> which contains 'Enabled' for every <a>supported
+    feature</a>, and a <a>declared policy</a> which is an empty map.</p>
   </section>
   <section>
     <h3 id="inherited-policies">Inherited policies</h3>
@@ -180,13 +180,13 @@ spec:fetch; type:dfn; text:value
     <p>The <dfn>inherited policy for a feature</dfn> <var>feature</var> is the
     value in the <a>inherited policy</a> whose key is <var>feature</var>. After
     a <a>feature policy</a> has been initialized, its <a>inherited policy</a>
-    will contain an value for each <a>supported feature</a>.</p>
+    will contain a value for each <a>supported feature</a>.</p>
     <div class="note">
     <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
     for each <a>policy-controlled feature</a>. This inherited policy determines
-    the initial state (enabled or disabled) of each feature, and whether it can
-    be controlled by a <a>declared policy</a> in the document.
+    the initial state ('Enabled' or 'Disabled') of each feature, and whether it
+    can be controlled by a <a>declared policy</a> in the document.
     </p>
     <p>In a {{Document}} in a [=top-level browsing context=], the inherited
     policy is based on defined defaults for each feature.</p>
@@ -855,18 +855,19 @@ partial interface HTMLIFrameElement {
               <li>If the <a>allowlist</a> for <var>feature</var> in
               <var>container policy</var> <a>matches</a> <var>origin</var>, and
               <var>parent</var>'s <a>inherited policy</a> for
-              <var>feature</var> is Enabled, return Enabled.
+              <var>feature</var> is 'Enabled', return 'Enabled'.
               </li>
-              <li>Otherwise return Disabled.</li>
+              <li>Otherwise return 'Disabled'.</li>
             </ol>
           </li>
-          <li>Otherwise, if <var>feature</var> is enabled in <var>parent</var>
-	  for <var>origin</var>, return Enabled.
+          <li>Otherwise, if <a href="is-feature-enabled"><var>feature</var> is
+	  enabled in <var>parent</var> for <var>origin</var></a>, return
+	  'Enabled'.
           </li>
-          <li>Otherwise, return Disabled.</li>
+          <li>Otherwise, return 'Disabled'.</li>
         </ol>
       </li>
-      <li>Otherwise, return Enabled.</li>
+      <li>Otherwise, return 'Enabled'.</li>
     </ol>
   </section>
   <section>

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 24e86bd5bd6c90b3d57bf1ee168df70f4e11d8c4" name="generator">
   <link href="https://wicg.github.io/feature-policy/" rel="canonical">
-  <meta content="ad17c1c94e6e7bd6e70066cb2b266ef0687e440f" name="document-revision">
+  <meta content="4067cf5020f168fb85d11895af060e40f4acfbf6" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1654,10 +1654,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     indicated, the term "feature" refers to <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature">policy-controlled features</a>.
     Other specifications, defining such features, should use the longer term to
     avoid any ambiguity.</div>
-     <div class="issue" id="issue-98af4289"><a class="self-link" href="#issue-98af4289"></a>This spec currently only deals with features defined in
+     <div class="issue" id="issue-db17541f"><a class="self-link" href="#issue-db17541f"></a>This spec currently only deals with features defined in
     Documents. We should figure out how to word this to include the possibility
-    of features in Workers as well, and for feature policies to be attached to
-    Workers.</div>
+    of features and feature policies in Workers and Worklets as well.</div>
      <p><a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①">Policy-controlled features</a> are identified by tokens, which are
     character strings used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive">policy directives</a>. </p>
      <p>Each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> has a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist">default allowlist</a>,
@@ -2552,8 +2551,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <div style="counter-reset:issue">
    <div class="issue">This spec currently only deals with features defined in
     Documents. We should figure out how to word this to include the possibility
-    of features in Workers as well, and for feature policies to be attached to
-    Workers.<a href="#issue-98af4289"> ↵ </a></div>
+    of features and feature policies in Workers and Worklets as well.<a href="#issue-db17541f"> ↵ </a></div>
    <div class="issue"> Monkey-patching! As soon as we know that this is the direction we wish to
       pursue, upstream all of this. <a href="#issue-7605d231"> ↵ </a></div>
    <div class="issue">TODO<a href="#issue-b7b1e314"> ↵ </a></div>

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 24e86bd5bd6c90b3d57bf1ee168df70f4e11d8c4" name="generator">
   <link href="https://wicg.github.io/feature-policy/" rel="canonical">
-  <meta content="4067cf5020f168fb85d11895af060e40f4acfbf6" name="document-revision">
+  <meta content="e69e6396e82b82cf295d78222d07ef9ba405dbb4" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-05-16">16 May 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-05-17">17 May 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1678,22 +1678,24 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>An <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy">inherited policy</a>. 
       <li>A <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy">declared policy</a>. 
      </ul>
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-feature-policy">empty feature policy</dfn> has an <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy①">inherited policy</a> which contains 'Enabled' for every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑥">policy-controlled feature</a> available, and a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy①">declared policy</a> which is an empty map.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-feature-policy">empty feature policy</dfn> is a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①">feature policy</a> that has
+    an <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy①">inherited policy</a> which contains 'Enabled' for every <a data-link-type="dfn" href="#supported-features" id="ref-for-supported-features">supported
+    feature</a>, and a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy①">declared policy</a> which is an empty map.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.3" id="inherited-policies"><span class="secno">4.3. </span><span class="content">Inherited policies</span><a class="self-link" href="#inherited-policies"></a></h3>
      <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="inherited policy|inherited policies" data-noexport="" id="inherited-policy">inherited
-    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑦">features</a> to either 'Enabled' or
+    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑥">features</a> to either 'Enabled' or
     'Disabled'.</p>
      <p>The <dfn data-dfn-type="dfn" data-noexport="" id="inherited-policy-for-a-feature">inherited policy for a feature<a class="self-link" href="#inherited-policy-for-a-feature"></a></dfn> <var>feature</var> is the
     value in the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy②">inherited policy</a> whose key is <var>feature</var>. After
-    a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①">feature policy</a> has been initialized, its <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy③">inherited policy</a> will contain an value for each <a data-link-type="dfn" href="#supported-features" id="ref-for-supported-features">supported feature</a>.</p>
+    a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy②">feature policy</a> has been initialized, its <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy③">inherited policy</a> will contain a value for each <a data-link-type="dfn" href="#supported-features" id="ref-for-supported-features①">supported feature</a>.</p>
      <div class="note" role="note">
       <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
-    for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑧">policy-controlled feature</a>. This inherited policy determines
-    the initial state (enabled or disabled) of each feature, and whether it can
-    be controlled by a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy②">declared policy</a> in the document. </p>
+    for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑦">policy-controlled feature</a>. This inherited policy determines
+    the initial state ('Enabled' or 'Disabled') of each feature, and whether it
+    can be controlled by a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy②">declared policy</a> in the document. </p>
       <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a>, the inherited
     policy is based on defined defaults for each feature.</p>
       <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, the inherited policy
@@ -1704,11 +1706,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="4.4" id="declared-policies"><span class="secno">4.4. </span><span class="content">Declared policies</span><a class="self-link" href="#declared-policies"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="declared policy|declared feature policy" data-noexport="" id="declared-policy">declared
-    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑨">features</a> to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①">allowlists</a>. </p>
+    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑧">features</a> to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①">allowlists</a>. </p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.5" id="header-policies"><span class="secno">4.5. </span><span class="content">Header policies</span><a class="self-link" href="#header-policies"></a></h3>
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="header-policy">header policy</dfn> is a list of <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive①">policy directives</a> delivered via an HTTP header with a document. This forms the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy②">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy③">declared policy</a>.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="header-policy">header policy</dfn> is a list of <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive①">policy directives</a> delivered via an HTTP header with a document. This forms the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy③">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy③">declared policy</a>.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.6" id="container-policies"><span class="secno">4.6. </span><span class="content">Container policies</span><a class="self-link" href="#container-policies"></a></h3>
@@ -1728,7 +1730,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="4.7" id="policy-directives"><span class="secno">4.7. </span><span class="content">Policy directives</span><a class="self-link" href="#policy-directives"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="policy directive|policy directives" data-noexport="" id="policy-directive">policy
-    directive</dfn> is an ordered map, mapping <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⓪">policy-controlled features</a> to corresponding <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist②">allowlists</a> of origins.</p>
+    directive</dfn> is an ordered map, mapping <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑨">policy-controlled features</a> to corresponding <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist②">allowlists</a> of origins.</p>
      <p>A <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive③">policy directive</a> is represented in HTTP headers and HTML
     attributes as its ASCII serialization.</p>
     </section>
@@ -1760,11 +1762,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="4.9" id="default-allowlists"><span class="secno">4.9. </span><span class="content">Default Allowlists</span><a class="self-link" href="#default-allowlists"></a></h3>
-     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①①">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="default allowlist|default allowlists" id="default-allowlist">default allowlist</dfn>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> determines whether the feature is allowed in a
+     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⓪">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="default allowlist|default allowlists" id="default-allowlist">default allowlist</dfn>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> determines whether the feature is allowed in a
     document with no declared policy in a top-level browsing context, and also
     whether access to the feature is automatically delegated to documents in
     nested browsing contexts.</p>
-     <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist②">default allowlist</a> for a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①②">feature</a> is one of these values:</p>
+     <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist②">default allowlist</a> for a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①①">feature</a> is one of these values:</p>
      <dl>
       <dt><code>*</code>
       <dd>The feature is allowed in documents in top-level browsing contexts by
@@ -1809,7 +1811,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="6.1" id="feature-policy-http-header-field"><span class="secno">6.1. </span><span class="content">Feature-Policy HTTP Header
     Field</span><a class="self-link" href="#feature-policy-http-header-field"></a></h3>
      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="feature-policy-header" data-noexport="" id="feature-policy-header">Feature-Policy</dfn> HTTP header
-    field can be used in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response">response</a> (server to client) to communicate the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy③">feature policy</a> that should be enforced by the client.</p>
+    field can be used in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response">response</a> (server to client) to communicate the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy④">feature policy</a> that should be enforced by the client.</p>
      <p>The header’s value is the <a href="#ascii-serialization">§5.1 ASCII serialization</a> of one or
     more <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive⑤">policy directive</a>s:.</p>
 <pre class="abnf">FeaturePolicy = <a data-link-type="dfn" href="#serialized-feature-policy" id="ref-for-serialized-feature-policy">serialized-feature-policy</a> *("," <a data-link-type="dfn" href="#serialized-feature-policy" id="ref-for-serialized-feature-policy①">serialized-feature-policy</a>)
@@ -1829,12 +1831,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     that case, the default value for the allowlist is <code>'src'</code>, which
     represents the origin of the URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src" id="ref-for-attr-iframe-src">src</a></code> attribute. </p>
      <p>When not empty, the "<code>allow</code>" attribute will result in adding
-    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑦">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①③">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy④">container policy</a>, when it is constructed.</p>
+    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑦">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①②">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy④">container policy</a>, when it is constructed.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.3" id="legacy-attributes"><span class="secno">6.3. </span><span class="content">Additional attributes to support legacy
     features</span><a class="self-link" href="#legacy-attributes"></a></h3>
-     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①④">features</a> controlled by
+     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①③">features</a> controlled by
     Feature Policy have existing iframe attributes defined. This specification
     redefines these attributes to act as declared policies for the iframe
     element.</p>
@@ -1899,7 +1901,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="7.1" id="integration-with-html"><span class="secno">7.1. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h3>
      <ol>
-      <li> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> objects have a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy④">Feature Policy</a>, which is initially <a data-link-type="dfn" href="#empty-feature-policy" id="ref-for-empty-feature-policy">empty</a>. 
+      <li> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> objects have a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑤">Feature Policy</a>, which is initially <a data-link-type="dfn" href="#empty-feature-policy" id="ref-for-empty-feature-policy">empty</a>. 
       <li>
        Replace the existing step 12 of "Create a new browsing context" with
       with the following step: 
@@ -1911,8 +1913,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <ul>
         <li> Execute the <a href="#initialize-from-response">Initialize document’s Feature Policy from response</a> algorithm on the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code> object and the response used to generate the document. 
        </ul>
-      <li>A <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑤">feature policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="enforce" data-noexport="" id="enforce">enforced</dfn> for
-      a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> by setting it as the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>'s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑥">Feature Policy</a>. 
+      <li>A <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑥">feature policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="enforce" data-noexport="" id="enforce">enforced</dfn> for
+      a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> by setting it as the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>'s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑦">Feature Policy</a>. 
       <li>
        <p>The "<a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use">allowed to use</a>" algorithm is replaced with the following: </p>
        <p>To determine whether a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> object <var>document</var> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed-to-use">allowed to use</dfn> the policy-controlled-feature <var>feature</var>, run these steps:</p>
@@ -1924,7 +1926,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
          <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active
 	 document</a> is not <var>document</var>, then return false.</p>
         <li>
-         <p>If <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑦">feature policy</a> <a href="#is-feature-enabled">enables <var>feature</var> for the origin of <var>document</var></a>, then return true.</p>
+         <p>If <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑧">feature policy</a> <a href="#is-feature-enabled">enables <var>feature</var> for the origin of <var>document</var></a>, then return true.</p>
          <p></p>
         <li>
          <p>Return false.</p>
@@ -1933,25 +1935,25 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <p>The <a href="#iframe-allow-attribute">allow attribute</a> is added
       to the IDL for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element②">iframe</a></code> element, with the description:</p>
        <p>The allow attribute, when specified, determines the <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑧">container
-      policy</a> that will be used when the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑧">feature policy</a> for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element③">iframe</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context①">nested browsing context</a> is initialized. Its value must be
+      policy</a> that will be used when the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑨">feature policy</a> for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element③">iframe</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context①">nested browsing context</a> is initialized. Its value must be
       the <a href="#ascii-serialization">§5.1 ASCII serialization</a> of a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive⑥">policy directive</a>.</p>
       <li>
        <p>The description of the behavior of the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen" id="ref-for-attr-iframe-allowfullscreen">allowfullscreen</a></code>, <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowpaymentrequest" id="ref-for-attr-iframe-allowpaymentrequest">allowpaymentrequest</a></code> and <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowusermedia" id="ref-for-attr-iframe-allowusermedia">allowusermedia</a></code> attributes is
       changed to refer to this specification: </p>
        <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen" id="ref-for-attr-iframe-allowfullscreen①">allowfullscreen</a></code> attribute is a boolean attribute. When
-      specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑨">feature
+      specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⓪">feature
       policy</a> which allows the <code>fullscreen</code> feature to be used
       from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the <code>fullscreen</code> feature if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑤">iframe</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use①">allowed to use</a> <code>fullscreen</code>. </p>
        <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowpaymentrequest" id="ref-for-attr-iframe-allowpaymentrequest①">allowpaymentrequest</a></code> attribute is a boolean attribute.
-      When specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑥">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⓪">feature
+      When specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑥">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①①">feature
       policy</a> which allows the <code>payment</code> feature to be used
       to make payment requests from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the <code>PaymentRequest</code> interface if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑦">iframe</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document①">node
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use②">allowed to use</a> the feature. </p>
        <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowusermedia" id="ref-for-attr-iframe-allowusermedia①">allowusermedia</a></code> attribute is a boolean attribute. When
-      specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⓪">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑧">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①①">feature
+      specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⓪">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑧">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①②">feature
       policy</a> which allows the <code>camera</code> and <code>microphone</code> features to be used to call <code>getUserMedia()</code> from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the <code>getUserMedia()</code> interface if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑨">iframe</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document②">node
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use③">allowed to use</a> the feature. </p>
@@ -2008,8 +2010,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>Let <var>tokens</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace">splitting <var>serialized-declaration</var> on ASCII whitespace.</a>
         <li>If <var>tokens</var> is an empty list, then continue.
         <li>Let <var>feature-name</var> be the first element of <var>tokens</var>.
-        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑤">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑥">policy-controlled feature</a> identified by <var>feature-name</var>.
+        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①④">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑤">policy-controlled feature</a> identified by <var>feature-name</var>.
         <li>Let <var>targetlist</var> be the remaining elements, if any, of <var>tokens</var>. 
         <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①①">allowlist</a>. 
         <li>If any element of <var>targetlist</var> is the string
@@ -2117,8 +2119,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>Let <var>tokens</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace①">splitting <var>serialized-declaration</var> on ASCII whitespace.</a>
         <li>If <var>tokens</var> is an empty list, then continue.
         <li>Let <var>feature-name</var> be the first element of <var>tokens</var>.
-        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑦">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑧">policy-controlled feature</a> identified by <var>feature-name</var>.
+        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑥">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑦">policy-controlled feature</a> identified by <var>feature-name</var>.
         <li>Let <var>targetlist</var> be the remaining elements, if any, of <var>tokens</var>. 
         <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①②">allowlist</a>. 
         <li>If any element of <var>targetlist</var> is the string
@@ -2155,7 +2157,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="8.7" id="initialize-for-document"><span class="secno">8.7. </span><span class="content">Initialize <var>document</var>’s Feature
     Policy</span><a class="self-link" href="#initialize-for-document"></a></h3>
      <p>Given a Document object (<var>document</var>), this algorithm
-    initialises <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①②">Feature Policy</a></p>
+    initialises <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①③">Feature Policy</a></p>
      <ol>
       <li>Let <var>inherited policy</var> be a new ordered map.
       <li>Let <var>declared policy</var> be a new ordered map.
@@ -2166,7 +2168,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     feature</a> on <var>feature</var> and <var>document</var>’s browsing context. 
         <li>Set <var>inherited policy</var>[<var>feature</var>] to <var>isInherited</var>.
        </ol>
-      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①③">feature policy</a>, with inherited
+      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①④">feature policy</a>, with inherited
       policy <var>inherited policy</var> and declared policy <var>declared
       policy</var>. 
       <li> <a data-link-type="dfn" href="#enforce" id="ref-for-enforce①">Enforce</a> the policy <var>policy</var> on <var>document</var>. 
@@ -2176,7 +2178,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="8.8" id="initialize-from-response"><span class="secno">8.8. </span><span class="content">Initialize <var>document</var>’s Feature
     Policy from <var>response</var></span><a class="self-link" href="#initialize-from-response"></a></h3>
      <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response②">response</a> (<var>response</var>) and a Document
-    (<var>document</var>), this algorithm populates <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①④">Feature Policy</a></p>
+    (<var>document</var>), this algorithm populates <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑤">Feature Policy</a></p>
      <ol>
       <li>Initialize <var>document</var>’s Feature Policy
       <li>Let <var>inherited policy</var> be <var>document</var>’s Feature
@@ -2189,7 +2191,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>If <var>inherited policy</var>[<var>feature</var>] is true, then
 	  set <var>declared policy</var>[<var>feature</var>] to <var>allowlist</var>.
        </ol>
-      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑤">feature policy</a>, with inherited
+      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑥">feature policy</a>, with inherited
       policy <var>inherited policy</var> and declared policy <var>declared
       policy</var>. 
       <li> <a data-link-type="dfn" href="#enforce" id="ref-for-enforce②">Enforce</a> the policy <var>policy</var> on <var>document</var>. 
@@ -2211,13 +2213,15 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>
          If <var>feature</var> is a key in <var>container policy</var>: 
          <ol>
-          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①③">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑦">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
-          <li>Otherwise return Disabled.
+          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①③">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑦">inherited policy</a> for <var>feature</var> is 'Enabled', return 'Enabled'. 
+          <li>Otherwise return 'Disabled'.
          </ol>
-        <li>Otherwise, if <var>feature</var> is enabled in <var>parent</var> for <var>origin</var>, return Enabled. 
-        <li>Otherwise, return Disabled.
+        <li>Otherwise, if <a href="is-feature-enabled"><var>feature</var> is
+	  enabled in <var>parent</var> for <var>origin</var></a>, return
+	  'Enabled'. 
+        <li>Otherwise, return 'Disabled'.
        </ol>
-      <li>Otherwise, return Enabled.
+      <li>Otherwise, return 'Enabled'.
      </ol>
     </section>
     <section>
@@ -2227,7 +2231,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     returns "<code>Disabled</code>" if <var>feature</var> should be considered
     disabled, and "<code>Enabled</code>" otherwise.</p>
      <ol>
-      <li>Let <var>policy</var> be <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑥">Feature Policy</a> 
+      <li>Let <var>policy</var> be <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑦">Feature Policy</a> 
       <li>If <var>policy</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑧">inherited policy</a> for <var>feature</var> is Disabled, return "<code>Disabled</code>".
       <li>
        If <var>feature</var> is present in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑥">declared
@@ -2560,40 +2564,41 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#policy-controlled-feature">#policy-controlled-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">4.1. Policy-controlled Features</a> <a href="#ref-for-policy-controlled-feature①">(2)</a> <a href="#ref-for-policy-controlled-feature②">(3)</a> <a href="#ref-for-policy-controlled-feature③">(4)</a> <a href="#ref-for-policy-controlled-feature④">(5)</a> <a href="#ref-for-policy-controlled-feature⑤">(6)</a>
-    <li><a href="#ref-for-policy-controlled-feature⑥">4.2. Policies</a>
-    <li><a href="#ref-for-policy-controlled-feature⑦">4.3. Inherited policies</a> <a href="#ref-for-policy-controlled-feature⑧">(2)</a>
-    <li><a href="#ref-for-policy-controlled-feature⑨">4.4. Declared policies</a>
-    <li><a href="#ref-for-policy-controlled-feature①⓪">4.7. Policy directives</a>
-    <li><a href="#ref-for-policy-controlled-feature①①">4.9. Default Allowlists</a> <a href="#ref-for-policy-controlled-feature①②">(2)</a>
-    <li><a href="#ref-for-policy-controlled-feature①③">6.2. The allow attribute of the
+    <li><a href="#ref-for-policy-controlled-feature⑥">4.3. Inherited policies</a> <a href="#ref-for-policy-controlled-feature⑦">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature⑧">4.4. Declared policies</a>
+    <li><a href="#ref-for-policy-controlled-feature⑨">4.7. Policy directives</a>
+    <li><a href="#ref-for-policy-controlled-feature①⓪">4.9. Default Allowlists</a> <a href="#ref-for-policy-controlled-feature①①">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①②">6.2. The allow attribute of the
     iframe element</a>
-    <li><a href="#ref-for-policy-controlled-feature①④">6.3. Additional attributes to support legacy
+    <li><a href="#ref-for-policy-controlled-feature①③">6.3. Additional attributes to support legacy
     features</a>
-    <li><a href="#ref-for-policy-controlled-feature①⑤">8.3. Parse policy directive from
-    value and origin</a> <a href="#ref-for-policy-controlled-feature①⑥">(2)</a>
-    <li><a href="#ref-for-policy-controlled-feature①⑦">8.6. Parse allow attribute</a> <a href="#ref-for-policy-controlled-feature①⑧">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①④">8.3. Parse policy directive from
+    value and origin</a> <a href="#ref-for-policy-controlled-feature①⑤">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①⑥">8.6. Parse allow attribute</a> <a href="#ref-for-policy-controlled-feature①⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="supported-features">
    <b><a href="#supported-features">#supported-features</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-supported-features">4.3. Inherited policies</a>
+    <li><a href="#ref-for-supported-features">4.2. Policies</a>
+    <li><a href="#ref-for-supported-features①">4.3. Inherited policies</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="feature-policy">
    <b><a href="#feature-policy">#feature-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-policy">4.1. Policy-controlled Features</a>
-    <li><a href="#ref-for-feature-policy①">4.3. Inherited policies</a>
-    <li><a href="#ref-for-feature-policy②">4.5. Header policies</a>
-    <li><a href="#ref-for-feature-policy③">6.1. Feature-Policy HTTP Header
+    <li><a href="#ref-for-feature-policy①">4.2. Policies</a>
+    <li><a href="#ref-for-feature-policy②">4.3. Inherited policies</a>
+    <li><a href="#ref-for-feature-policy③">4.5. Header policies</a>
+    <li><a href="#ref-for-feature-policy④">6.1. Feature-Policy HTTP Header
     Field</a>
-    <li><a href="#ref-for-feature-policy④">7.1. Integration with HTML</a> <a href="#ref-for-feature-policy⑤">(2)</a> <a href="#ref-for-feature-policy⑥">(3)</a> <a href="#ref-for-feature-policy⑦">(4)</a> <a href="#ref-for-feature-policy⑧">(5)</a> <a href="#ref-for-feature-policy⑨">(6)</a> <a href="#ref-for-feature-policy①⓪">(7)</a> <a href="#ref-for-feature-policy①①">(8)</a>
-    <li><a href="#ref-for-feature-policy①②">8.7. Initialize document’s Feature
-    Policy</a> <a href="#ref-for-feature-policy①③">(2)</a>
-    <li><a href="#ref-for-feature-policy①④">8.8. Initialize document’s Feature
-    Policy from response</a> <a href="#ref-for-feature-policy①⑤">(2)</a>
-    <li><a href="#ref-for-feature-policy①⑥">8.10. Is feature enabled in
+    <li><a href="#ref-for-feature-policy⑤">7.1. Integration with HTML</a> <a href="#ref-for-feature-policy⑥">(2)</a> <a href="#ref-for-feature-policy⑦">(3)</a> <a href="#ref-for-feature-policy⑧">(4)</a> <a href="#ref-for-feature-policy⑨">(5)</a> <a href="#ref-for-feature-policy①⓪">(6)</a> <a href="#ref-for-feature-policy①①">(7)</a> <a href="#ref-for-feature-policy①②">(8)</a>
+    <li><a href="#ref-for-feature-policy①③">8.7. Initialize document’s Feature
+    Policy</a> <a href="#ref-for-feature-policy①④">(2)</a>
+    <li><a href="#ref-for-feature-policy①⑤">8.8. Initialize document’s Feature
+    Policy from response</a> <a href="#ref-for-feature-policy①⑥">(2)</a>
+    <li><a href="#ref-for-feature-policy①⑦">8.10. Is feature enabled in
     document for origin?</a>
    </ul>
   </aside>

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 24e86bd5bd6c90b3d57bf1ee168df70f4e11d8c4" name="generator">
   <link href="https://wicg.github.io/feature-policy/" rel="canonical">
-  <meta content="626ff9591aed540ce81e01b9d90e9b5680795bea" name="document-revision">
+  <meta content="ad17c1c94e6e7bd6e70066cb2b266ef0687e440f" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-05-14">14 May 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-05-16">16 May 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1676,27 +1676,29 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="4.2" id="policies"><span class="secno">4.2. </span><span class="content">Policies</span><a class="self-link" href="#policies"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-policy">feature policy</dfn> is a struct with the following items:</p>
      <ul>
-      <li>A set of <a data-link-type="dfn" href="#inherited-policy-set" id="ref-for-inherited-policy-set">inherited policies</a>. 
+      <li>An <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy">inherited policy</a>. 
       <li>A <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy">declared policy</a>. 
      </ul>
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-feature-policy">empty feature policy</dfn> has an <a data-link-type="dfn" href="#inherited-policy-set" id="ref-for-inherited-policy-set①">inherited policy set</a> which contains 'Enabled' for every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑥">policy-controlled feature</a> available, and a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy①">declared policy</a> which is an empty map.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-feature-policy">empty feature policy</dfn> has an <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy①">inherited policy</a> which contains 'Enabled' for every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑥">policy-controlled feature</a> available, and a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy①">declared policy</a> which is an empty map.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.3" id="inherited-policies"><span class="secno">4.3. </span><span class="content">Inherited policies</span><a class="self-link" href="#inherited-policies"></a></h3>
      <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="inherited policy|inherited policies" data-noexport="" id="inherited-policy">inherited
-    policy</dfn> is either 'Enabled' or 'Disabled'.</p>
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inherited-policy-set">inherited policy set</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑦">features</a> to <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy">inherited
-    policies</a>. After a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①">feature policy</a> has been initialized, its <a data-link-type="dfn" href="#inherited-policy-set" id="ref-for-inherited-policy-set②">inherited policy set</a> will contain an <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy①">inherited policy</a> for each <a data-link-type="dfn" href="#supported-features" id="ref-for-supported-features">supported feature</a>.</p>
+    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑦">features</a> to either 'Enabled' or
+    'Disabled'.</p>
+     <p>The <dfn data-dfn-type="dfn" data-noexport="" id="inherited-policy-for-a-feature">inherited policy for a feature<a class="self-link" href="#inherited-policy-for-a-feature"></a></dfn> <var>feature</var> is the
+    value in the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy②">inherited policy</a> whose key is <var>feature</var>. After
+    a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①">feature policy</a> has been initialized, its <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy③">inherited policy</a> will contain an value for each <a data-link-type="dfn" href="#supported-features" id="ref-for-supported-features">supported feature</a>.</p>
      <div class="note" role="note">
       <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
-    for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑧">policy-controlled feature</a>. This inherited policy set
-    determines the initial state (enabled or disabled) of each feature, and
-    whether it can be controlled by a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy②">declared policy</a> in the document. </p>
+    for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑧">policy-controlled feature</a>. This inherited policy determines
+    the initial state (enabled or disabled) of each feature, and whether it can
+    be controlled by a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy②">declared policy</a> in the document. </p>
       <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a>, the inherited
-    feature set is based on defined defaults for each feature.</p>
-      <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, the inherited feature
-    set is based on the parent document’s feature policy, as well as any <a href="#iframe-allow-attribute">allow attributes</a> defined on the
+    policy is based on defined defaults for each feature.</p>
+      <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, the inherited policy
+    is based on the parent document’s feature policy, as well as any <a href="#iframe-allow-attribute">allow attributes</a> defined on the
     browsing context container.</p>
      </div>
     </section>
@@ -1714,7 +1716,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <p>In addition to the <a data-link-type="dfn" href="#header-policy" id="ref-for-header-policy">header policy</a>, each frame has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="container policy" data-noexport="" id="container-policy">container
     policy</dfn>, which is a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive②">policy directive</a>, which may be empty. The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy">container policy</a> can set by attributes on the browsing context
     container.</p>
-     <p>The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy①">container policy</a> for a frame influences the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy②">inherited
+     <p>The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy①">container policy</a> for a frame influences the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy④">inherited
     policy</a> of any document loaded into that frame. (See <a href="#define-inherited-policy">§8.9 Define an inherited policy for
     feature</a>)</p>
      <div class="note" role="note"> Currently, the <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy②">container policy</a> cannot be set directly, but is
@@ -2156,17 +2158,18 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <p>Given a Document object (<var>document</var>), this algorithm
     initialises <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①②">Feature Policy</a></p>
      <ol>
-      <li>Let <var>inherited policies</var> be a new ordered map.
-      <li>Let <var>declared policies</var> be a new ordered map.
+      <li>Let <var>inherited policy</var> be a new ordered map.
+      <li>Let <var>declared policy</var> be a new ordered map.
       <li>
        For each <var>feature</var> supported, 
        <ol>
         <li>Let <var>isInherited</var> be the result of running <a href="#define-inherited-policy">§8.9 Define an inherited policy for
     feature</a> on <var>feature</var> and <var>document</var>’s browsing context. 
-        <li>Set <var>inherited policies</var>[<var>feature</var>] to <var>isInherited</var>.
+        <li>Set <var>inherited policy</var>[<var>feature</var>] to <var>isInherited</var>.
        </ol>
       <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①③">feature policy</a>, with inherited
-      policy set <var>inherited policies</var> and declared policy set <var>declared policies</var>. 
+      policy <var>inherited policy</var> and declared policy <var>declared
+      policy</var>. 
       <li> <a data-link-type="dfn" href="#enforce" id="ref-for-enforce①">Enforce</a> the policy <var>policy</var> on <var>document</var>. 
      </ol>
     </section>
@@ -2177,25 +2180,26 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     (<var>document</var>), this algorithm populates <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①④">Feature Policy</a></p>
      <ol>
       <li>Initialize <var>document</var>’s Feature Policy
-      <li>Let <var>inherited policies</var> be <var>document</var>’s Feature
-      Policy’s inherited policy set.
-      <li>Let <var>declared policies</var> be a new ordered map.
+      <li>Let <var>inherited policy</var> be <var>document</var>’s Feature
+      Policy’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑤">inherited policy</a>.
+      <li>Let <var>declared policy</var> be a new ordered map.
       <li>Let <var>d</var> be the result of running <a href="#process-response-policy">Process response policy</a> on <var>response</var> and <var>document</var>’s origin.
       <li>
        For each <var>feature</var> → <var>allowlist</var> of <var>d</var>: 
        <ol>
-        <li>If <var>inherited policies</var>[<var>feature</var>] is true, then
-	  set <var>declared policies</var>[<var>feature</var>] to <var>allowlist</var>.
+        <li>If <var>inherited policy</var>[<var>feature</var>] is true, then
+	  set <var>declared policy</var>[<var>feature</var>] to <var>allowlist</var>.
        </ol>
       <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑤">feature policy</a>, with inherited
-      policy set <var>inherited policies</var> and declared policy set <var>declared policies</var>. 
+      policy <var>inherited policy</var> and declared policy <var>declared
+      policy</var>. 
       <li> <a data-link-type="dfn" href="#enforce" id="ref-for-enforce②">Enforce</a> the policy <var>policy</var> on <var>document</var>. 
      </ol>
     </section>
     <section>
      <h3 class="heading settled" data-level="8.9" id="define-inherited-policy"><span class="secno">8.9. </span><span class="content">Define an inherited policy for <var>feature</var></span><a class="self-link" href="#define-inherited-policy"></a></h3>
-     <p>Given a string (<var>feature</var>) and a browsing context
-    (<var>context</var>), this algorithm returns the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy③">inherited policy</a> for that feature.</p>
+     <p>Given a feature (<var>feature</var>) and a browsing context
+    (<var>context</var>), this algorithm returns the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑥">inherited policy</a> for that feature.</p>
      <ol>
       <li>
        If <var>context</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context②">nested browsing context</a>: 
@@ -2208,10 +2212,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>
          If <var>feature</var> is a key in <var>container policy</var>: 
          <ol>
-          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①③">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy④">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
+          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①③">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑦">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
           <li>Otherwise return Disabled.
          </ol>
-        <li>Otherwise, if feature is enabled in <var>parent</var> for <var>origin</var>, return Enabled. 
+        <li>Otherwise, if <var>feature</var> is enabled in <var>parent</var> for <var>origin</var>, return Enabled. 
         <li>Otherwise, return Disabled.
        </ol>
       <li>Otherwise, return Enabled.
@@ -2225,7 +2229,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     disabled, and "<code>Enabled</code>" otherwise.</p>
      <ol>
       <li>Let <var>policy</var> be <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑥">Feature Policy</a> 
-      <li>If <var>policy</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑤">inherited policy</a> for <var>feature</var> is Disabled, return "<code>Disabled</code>".
+      <li>If <var>policy</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑧">inherited policy</a> for <var>feature</var> is Disabled, return "<code>Disabled</code>".
       <li>
        If <var>feature</var> is present in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑥">declared
       policy</a>: 
@@ -2429,7 +2433,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#header-policy">header policy</a><span>, in §4.5</span>
    <li><a href="#inherited-policy">inherited policies</a><span>, in §4.3</span>
    <li><a href="#inherited-policy">inherited policy</a><span>, in §4.3</span>
-   <li><a href="#inherited-policy-set">inherited policy set</a><span>, in §4.3</span>
+   <li><a href="#inherited-policy-for-a-feature">inherited policy for a feature</a><span>, in §4.3</span>
    <li><a href="#matches">matches</a><span>, in §4.8</span>
    <li><a href="#policy-controlled-feature">policy-controlled feature</a><span>, in §4.1</span>
    <li><a href="#policy-directive">policy directive</a><span>, in §4.7</span>
@@ -2604,19 +2608,15 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="inherited-policy">
    <b><a href="#inherited-policy">#inherited-policy</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-inherited-policy">4.3. Inherited policies</a> <a href="#ref-for-inherited-policy①">(2)</a>
-    <li><a href="#ref-for-inherited-policy②">4.6. Container policies</a>
-    <li><a href="#ref-for-inherited-policy③">8.9. Define an inherited policy for
-    feature</a> <a href="#ref-for-inherited-policy④">(2)</a>
-    <li><a href="#ref-for-inherited-policy⑤">8.10. Is feature enabled in
+    <li><a href="#ref-for-inherited-policy">4.2. Policies</a> <a href="#ref-for-inherited-policy①">(2)</a>
+    <li><a href="#ref-for-inherited-policy②">4.3. Inherited policies</a> <a href="#ref-for-inherited-policy③">(2)</a>
+    <li><a href="#ref-for-inherited-policy④">4.6. Container policies</a>
+    <li><a href="#ref-for-inherited-policy⑤">8.8. Initialize document’s Feature
+    Policy from response</a>
+    <li><a href="#ref-for-inherited-policy⑥">8.9. Define an inherited policy for
+    feature</a> <a href="#ref-for-inherited-policy⑦">(2)</a>
+    <li><a href="#ref-for-inherited-policy⑧">8.10. Is feature enabled in
     document for origin?</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="inherited-policy-set">
-   <b><a href="#inherited-policy-set">#inherited-policy-set</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-inherited-policy-set">4.2. Policies</a> <a href="#ref-for-inherited-policy-set①">(2)</a>
-    <li><a href="#ref-for-inherited-policy-set②">4.3. Inherited policies</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="declared-policy">

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 24e86bd5bd6c90b3d57bf1ee168df70f4e11d8c4" name="generator">
   <link href="https://wicg.github.io/feature-policy/" rel="canonical">
-  <meta content="6cb618fcf86fc020442301354224bb649e4bf730" name="document-revision">
+  <meta content="626ff9591aed540ce81e01b9d90e9b5680795bea" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-05-11">11 May 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-05-14">14 May 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1647,13 +1647,17 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="4.1" id="features"><span class="secno">4.1. </span><span class="content">Policy-controlled Features</span><a class="self-link" href="#features"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-controlled-feature">policy-controlled feature</dfn> is an
-    API or behaviour which can be enabled or disabled in a browsing context by
-    referring to it in a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy">feature policy</a>. </p>
+    API or behaviour which can be enabled or disabled in a document by referring
+    to it in a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy">feature policy</a>. </p>
      <div class="note" role="note">For brevity, policy-controlled features will often be
     referred to in this document simply as "Features". Unless otherwise
     indicated, the term "feature" refers to <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature">policy-controlled features</a>.
     Other specifications, defining such features, should use the longer term to
     avoid any ambiguity.</div>
+     <div class="issue" id="issue-98af4289"><a class="self-link" href="#issue-98af4289"></a>This spec currently only deals with features defined in
+    Documents. We should figure out how to word this to include the possibility
+    of features in Workers as well, and for feature policies to be attached to
+    Workers.</div>
      <p><a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①">Policy-controlled features</a> are identified by tokens, which are
     character strings used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive">policy directives</a>. </p>
      <p>Each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> has a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist">default allowlist</a>,
@@ -2542,6 +2546,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
+   <div class="issue">This spec currently only deals with features defined in
+    Documents. We should figure out how to word this to include the possibility
+    of features in Workers as well, and for feature policies to be attached to
+    Workers.<a href="#issue-98af4289"> ↵ </a></div>
    <div class="issue"> Monkey-patching! As soon as we know that this is the direction we wish to
       pursue, upstream all of this. <a href="#issue-7605d231"> ↵ </a></div>
    <div class="issue">TODO<a href="#issue-b7b1e314"> ↵ </a></div>

--- a/index.html
+++ b/index.html
@@ -1176,9 +1176,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version ae5d415446a9edf0c07d32303ac1d21767d86d57" name="generator">
+  <meta content="Bikeshed version 24e86bd5bd6c90b3d57bf1ee168df70f4e11d8c4" name="generator">
   <link href="https://wicg.github.io/feature-policy/" rel="canonical">
-  <meta content="8361c83b7e839c8743b38d75edbe0b66a2136754" name="document-revision">
+  <meta content="6cb618fcf86fc020442301354224bb649e4bf730" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Feature Policy</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-03-23">23 March 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2018-05-11">11 May 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1647,8 +1647,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="4.1" id="features"><span class="secno">4.1. </span><span class="content">Policy-controlled Features</span><a class="self-link" href="#features"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="policy-controlled-feature">policy-controlled feature</dfn> is an
-    API or behaviour which can be enabled or disabled in a document by referring
-    to it in a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy">feature policy</a>. </p>
+    API or behaviour which can be enabled or disabled in a browsing context by
+    referring to it in a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy">feature policy</a>. </p>
      <div class="note" role="note">For brevity, policy-controlled features will often be
     referred to in this document simply as "Features". Unless otherwise
     indicated, the term "feature" refers to <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature">policy-controlled features</a>.
@@ -1657,9 +1657,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <p><a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①">Policy-controlled features</a> are identified by tokens, which are
     character strings used in <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive">policy directives</a>. </p>
      <p>Each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature②">policy-controlled feature</a> has a <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist">default allowlist</a>,
-    which defines whether that feature is available to top-level documents, and
-    how access to that feature is inherited by cross-origin frames.</p>
-     <p>A user agent has a set of <dfn data-dfn-type="dfn" data-noexport="" id="supported-features">supported features<a class="self-link" href="#supported-features"></a></dfn>, which is the set
+    which defines whether that feature is available in documents in top-level
+    browsing contexts, and how access to that feature is inherited in nested
+    browsing contexts.</p>
+     <p>A user agent has a set of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="supported-features">supported features</dfn>, which is the set
     of <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature③">features</a> which it allows to be
     controlled through policies. User agents are not required to support every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature④">feature</a>.</p>
      <div class="note" role="note"> The <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑤">policy-controlled features</a> themselves are not themselves part
@@ -1669,7 +1670,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="4.2" id="policies"><span class="secno">4.2. </span><span class="content">Policies</span><a class="self-link" href="#policies"></a></h3>
-     <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-policy">feature policy</dfn>, which consists of:</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-policy">feature policy</dfn> is a struct with the following items:</p>
      <ul>
       <li>A set of <a data-link-type="dfn" href="#inherited-policy-set" id="ref-for-inherited-policy-set">inherited policies</a>. 
       <li>A <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy">declared policy</a>. 
@@ -1678,37 +1679,38 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="4.3" id="inherited-policies"><span class="secno">4.3. </span><span class="content">Inherited policies</span><a class="self-link" href="#inherited-policies"></a></h3>
-     <p>Each document in a frame tree inherits a set of policies from its parent
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="inherited policy|inherited policies" data-noexport="" id="inherited-policy">inherited
+    policy</dfn> is either 'Enabled' or 'Disabled'.</p>
+     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inherited-policy-set">inherited policy set</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑦">features</a> to <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy">inherited
+    policies</a>. After a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①">feature policy</a> has been initialized, its <a data-link-type="dfn" href="#inherited-policy-set" id="ref-for-inherited-policy-set②">inherited policy set</a> will contain an <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy①">inherited policy</a> for each <a data-link-type="dfn" href="#supported-features" id="ref-for-supported-features">supported feature</a>.</p>
+     <div class="note" role="note">
+      <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
-    for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑦">policy-controlled feature</a>. This inherited policy set
+    for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑧">policy-controlled feature</a>. This inherited policy set
     determines the initial state (enabled or disabled) of each feature, and
     whether it can be controlled by a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy②">declared policy</a> in the document. </p>
-     <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a>, the inherited
+      <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing context</a>, the inherited
     feature set is based on defined defaults for each feature.</p>
-     <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, the inherited feature
+      <p>In a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context">nested browsing context</a>, the inherited feature
     set is based on the parent document’s feature policy, as well as any <a href="#iframe-allow-attribute">allow attributes</a> defined on the
     browsing context container.</p>
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="inherited policy|inherited policies" data-noexport="" id="inherited-policy">inherited
-    policy</dfn> declares a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑧">feature</a> as Enabled or Disabled.</p>
-     <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="inherited-policy-set">inherited policy set</dfn> for a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code> is the set of <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy">inherited policies</a> for each <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑨">feature</a> available in that scope.</p>
+     </div>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.4" id="declared-policies"><span class="secno">4.4. </span><span class="content">Declared policies</span><a class="self-link" href="#declared-policies"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="declared policy|declared feature policy" data-noexport="" id="declared-policy">declared
-    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⓪">features</a> to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①">allowlists</a>. </p>
-     <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code> is considered <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="feature-policy-aware">feature-policy-aware</dfn> if it has a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy③">declared policy</a> which is not empty.</p>
-     <p>A <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> which is not <a data-link-type="dfn" href="#feature-policy-aware" id="ref-for-feature-policy-aware">feature-policy-aware</a> is considered <dfn data-dfn-type="dfn" data-noexport="" id="feature-policy-oblivious">feature-policy-oblivious<a class="self-link" href="#feature-policy-oblivious"></a></dfn>.</p>
+    policy</dfn> is an ordered map from <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature⑨">features</a> to <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①">allowlists</a>. </p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.5" id="header-policies"><span class="secno">4.5. </span><span class="content">Header policies</span><a class="self-link" href="#header-policies"></a></h3>
-     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="header-policy">header policy</dfn> is a list of <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive①">policy directives</a> delivered via an HTTP header with the document. This forms the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy④">declared policy</a>.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="header-policy">header policy</dfn> is a list of <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive①">policy directives</a> delivered via an HTTP header with a document. This forms the document’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy②">feature policy</a>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy③">declared policy</a>.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.6" id="container-policies"><span class="secno">4.6. </span><span class="content">Container policies</span><a class="self-link" href="#container-policies"></a></h3>
      <p>In addition to the <a data-link-type="dfn" href="#header-policy" id="ref-for-header-policy">header policy</a>, each frame has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="container policy" data-noexport="" id="container-policy">container
     policy</dfn>, which is a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive②">policy directive</a>, which may be empty. The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy">container policy</a> can set by attributes on the browsing context
     container.</p>
-     <p>The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy①">container policy</a> for a frame influences the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy①">inherited
+     <p>The <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy①">container policy</a> for a frame influences the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy②">inherited
     policy</a> of any document loaded into that frame. (See <a href="#define-inherited-policy">§8.9 Define an inherited policy for
     feature</a>)</p>
      <div class="note" role="note"> Currently, the <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy②">container policy</a> cannot be set directly, but is
@@ -1721,7 +1723,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="4.7" id="policy-directives"><span class="secno">4.7. </span><span class="content">Policy directives</span><a class="self-link" href="#policy-directives"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="policy directive|policy directives" data-noexport="" id="policy-directive">policy
-    directive</dfn> is an ordered map, mapping <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①①">policy-controlled features</a> to corresponding <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist②">allowlists</a> of origins.</p>
+    directive</dfn> is an ordered map, mapping <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⓪">policy-controlled features</a> to corresponding <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist②">allowlists</a> of origins.</p>
      <p>A <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive③">policy directive</a> is represented in HTTP headers and HTML
     attributes as its ASCII serialization.</p>
     </section>
@@ -1753,23 +1755,25 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     </section>
     <section>
      <h3 class="heading settled" data-level="4.9" id="default-allowlists"><span class="secno">4.9. </span><span class="content">Default Allowlists</span><a class="self-link" href="#default-allowlists"></a></h3>
-     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①②">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="default allowlist|default allowlists" id="default-allowlist">default allowlist</dfn>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> controls the origins which are allowed to access
-    the feature when used in a top-level document with no declared policy, and
-    also determines whether access to the feature is automatically delegated to
-    child documents.</p>
-     <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist②">default allowlist</a> for a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①③">feature</a> is one of these values:</p>
+     <p>Every <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①①">policy-controlled feature</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" data-lt="default allowlist|default allowlists" id="default-allowlist">default allowlist</dfn>. The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist①">default allowlist</a> determines whether the feature is allowed in a
+    document with no declared policy in a top-level browsing context, and also
+    whether access to the feature is automatically delegated to documents in
+    nested browsing contexts.</p>
+     <p>The <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist②">default allowlist</a> for a <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①②">feature</a> is one of these values:</p>
      <dl>
       <dt><code>*</code>
-      <dd>The feature is allowed at the top level by default, and when allowed,
-      is allowed by default to documents in child frames.
+      <dd>The feature is allowed in documents in top-level browsing contexts by
+      default, and when allowed, is allowed by default to documents in nested
+      browsing contexts.
       <dt><code>'self'</code>
-      <dd>The feature is allowed at the top level by default, and when allowed,
-      is allowed by default to same-origin domain documents in child frames,
-      but is disallowed by default in cross-origin documents in child
-      frames.
+      <dd>The feature is allowed in documents in top-level browsing contexts by
+      default, and when allowed, is allowed by default to same-origin domain
+      documents in nested browsing contexts, but is disallowed by default in
+      cross-origin documents in nested browsing contexts.
       <dt>'none'
-      <dd>The feature is disallowed at the top level by default, and is also
-      disallowed by default to documents in child frames.
+      <dd>The feature is disallowed in documents in top-level browsing contexts
+      by default, and is also disallowed by default to documents in nested
+      browsing contexts.
      </dl>
     </section>
    </section>
@@ -1800,7 +1804,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="6.1" id="feature-policy-http-header-field"><span class="secno">6.1. </span><span class="content">Feature-Policy HTTP Header
     Field</span><a class="self-link" href="#feature-policy-http-header-field"></a></h3>
      <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="feature-policy-header" data-noexport="" id="feature-policy-header">Feature-Policy</dfn> HTTP header
-    field can be used in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response">response</a> (server to client) to communicate the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy②">feature policy</a> that should be enforced by the client.</p>
+    field can be used in the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response">response</a> (server to client) to communicate the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy③">feature policy</a> that should be enforced by the client.</p>
      <p>The header’s value is the <a href="#ascii-serialization">§5.1 ASCII serialization</a> of one or
     more <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive⑤">policy directive</a>s:.</p>
 <pre class="abnf">FeaturePolicy = <a data-link-type="dfn" href="#serialized-feature-policy" id="ref-for-serialized-feature-policy">serialized-feature-policy</a> *("," <a data-link-type="dfn" href="#serialized-feature-policy" id="ref-for-serialized-feature-policy①">serialized-feature-policy</a>)
@@ -1820,12 +1824,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     that case, the default value for the allowlist is <code>'src'</code>, which
     represents the origin of the URL in the iframe’s <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src" id="ref-for-attr-iframe-src">src</a></code> attribute. </p>
      <p>When not empty, the "<code>allow</code>" attribute will result in adding
-    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑦">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①④">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy④">container policy</a>, when it is constructed.</p>
+    an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist⑦">allowlist</a> for each recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①③">feature</a> to the frame’s <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy④">container policy</a>, when it is constructed.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.3" id="legacy-attributes"><span class="secno">6.3. </span><span class="content">Additional attributes to support legacy
     features</span><a class="self-link" href="#legacy-attributes"></a></h3>
-     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑤">features</a> controlled by
+     <p>Some <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①④">features</a> controlled by
     Feature Policy have existing iframe attributes defined. This specification
     redefines these attributes to act as declared policies for the iframe
     element.</p>
@@ -1890,23 +1894,23 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="7.1" id="integration-with-html"><span class="secno">7.1. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-with-html"></a></h3>
      <ol>
-      <li> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> objects have a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy③">Feature Policy</a>, which is initially <a data-link-type="dfn" href="#empty-feature-policy" id="ref-for-empty-feature-policy">empty</a>. 
+      <li> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> objects have a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy④">Feature Policy</a>, which is initially <a data-link-type="dfn" href="#empty-feature-policy" id="ref-for-empty-feature-policy">empty</a>. 
       <li>
        Replace the existing step 12 of "Create a new browsing context" with
       with the following step: 
        <ul>
-        <li> Execute the <a href="#initialize-for-document">Initialize document’s Feature Policy</a> algorithm on the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> object. 
+        <li> Execute the <a href="#initialize-for-document">Initialize document’s Feature Policy</a> algorithm on the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code> object. 
        </ul>
       <li>
        Replace the existing step 8 of "Initialising a new <code>Document</code> object" with the following step: 
        <ul>
-        <li> Execute the <a href="#initialize-from-response">Initialize document’s Feature Policy from response</a> algorithm on the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> object and the response used to generate the document. 
+        <li> Execute the <a href="#initialize-from-response">Initialize document’s Feature Policy from response</a> algorithm on the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code> object and the response used to generate the document. 
        </ul>
-      <li>A <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy④">feature policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="enforce" data-noexport="" id="enforce">enforced</dfn> for
-      a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> by setting it as the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⓪">Document</a></code>'s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑤">Feature Policy</a>. 
+      <li>A <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑤">feature policy</a> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="enforce" data-noexport="" id="enforce">enforced</dfn> for
+      a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> by setting it as the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>'s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑥">Feature Policy</a>. 
       <li>
        <p>The "<a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use">allowed to use</a>" algorithm is replaced with the following: </p>
-       <p>To determine whether a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①①">Document</a></code> object <var>document</var> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed-to-use">allowed to use</dfn> the policy-controlled-feature <var>feature</var>, run these steps:</p>
+       <p>To determine whether a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> object <var>document</var> is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="allowed-to-use">allowed to use</dfn> the policy-controlled-feature <var>feature</var>, run these steps:</p>
        <ol>
         <li>
          <p>If <var>document</var> has no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a>, then return
@@ -1915,7 +1919,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
          <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context①">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active
 	 document</a> is not <var>document</var>, then return false.</p>
         <li>
-         <p>If <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑥">feature policy</a> <a href="#is-feature-enabled">enables <var>feature</var> for the origin of <var>document</var></a>, then return true.</p>
+         <p>If <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑦">feature policy</a> <a href="#is-feature-enabled">enables <var>feature</var> for the origin of <var>document</var></a>, then return true.</p>
          <p></p>
         <li>
          <p>Return false.</p>
@@ -1924,25 +1928,25 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <p>The <a href="#iframe-allow-attribute">allow attribute</a> is added
       to the IDL for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element②">iframe</a></code> element, with the description:</p>
        <p>The allow attribute, when specified, determines the <a data-link-type="dfn" href="#container-policy" id="ref-for-container-policy⑧">container
-      policy</a> that will be used when the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑦">feature policy</a> for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element③">iframe</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context①">nested browsing context</a> is initialized. Its value must be
+      policy</a> that will be used when the <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑧">feature policy</a> for the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element③">iframe</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context①">nested browsing context</a> is initialized. Its value must be
       the <a href="#ascii-serialization">§5.1 ASCII serialization</a> of a <a data-link-type="dfn" href="#policy-directive" id="ref-for-policy-directive⑥">policy directive</a>.</p>
       <li>
        <p>The description of the behavior of the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen" id="ref-for-attr-iframe-allowfullscreen">allowfullscreen</a></code>, <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowpaymentrequest" id="ref-for-attr-iframe-allowpaymentrequest">allowpaymentrequest</a></code> and <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowusermedia" id="ref-for-attr-iframe-allowusermedia">allowusermedia</a></code> attributes is
       changed to refer to this specification: </p>
        <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen" id="ref-for-attr-iframe-allowfullscreen①">allowfullscreen</a></code> attribute is a boolean attribute. When
-      specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①②">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑧">feature
+      specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element④">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context②">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑨">feature
       policy</a> which allows the <code>fullscreen</code> feature to be used
       from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the <code>fullscreen</code> feature if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑤">iframe</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use①">allowed to use</a> <code>fullscreen</code>. </p>
        <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowpaymentrequest" id="ref-for-attr-iframe-allowpaymentrequest①">allowpaymentrequest</a></code> attribute is a boolean attribute.
-      When specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①③">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑥">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy⑨">feature
+      When specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑥">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context③">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⓪">feature
       policy</a> which allows the <code>payment</code> feature to be used
       to make payment requests from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the <code>PaymentRequest</code> interface if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑦">iframe</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document①">node
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use②">allowed to use</a> the feature. </p>
        <p>The <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowusermedia" id="ref-for-attr-iframe-allowusermedia①">allowusermedia</a></code> attribute is a boolean attribute. When
-      specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①④">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑧">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⓪">feature
+      specified, it indicates that <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①⓪">Document</a></code> objects in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑧">iframe</a></code> element’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context④">browsing context</a> should be initialized with a <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①①">feature
       policy</a> which allows the <code>camera</code> and <code>microphone</code> features to be used to call <code>getUserMedia()</code> from any origin. This is enforced by the <a href="#process-feature-policy-attributes">Process feature policy
       attributes</a> algorithm. Note that this will only allow use of the <code>getUserMedia()</code> interface if the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element" id="ref-for-the-iframe-element⑨">iframe</a></code> element’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document②">node
       document</a> is also <a data-link-type="dfn" href="#allowed-to-use" id="ref-for-allowed-to-use③">allowed to use</a> the feature. </p>
@@ -1957,7 +1961,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <h2 class="heading settled" data-level="8" id="algorithms"><span class="secno">8. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
     <section>
      <h3 class="heading settled" data-level="8.1" id="process-response-policy"><span class="secno">8.1. </span><span class="content">Process response policy</span><a class="self-link" href="#process-response-policy"></a></h3>
-     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response①">response</a> (<var>response</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> (<var>origin</var>), this algorithm returns a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑤">declared feature
+     <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response①">response</a> (<var>response</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin②">origin</a> (<var>origin</var>), this algorithm returns a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy④">declared feature
     policy</a>.</p>
      <ol>
       <li>Abort these steps if the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list">header list</a> does not contain a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header">header</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name" id="ref-for-concept-header-name">name</a> is "<code>Feature-Policy</code>". 
@@ -1972,7 +1976,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="8.2" id="parse-header"><span class="secno">8.2. </span><span class="content">Parse header from <var>value</var> and <var>origin</var></span><a class="self-link" href="#parse-header"></a></h3>
      <p>Given a string (<var>value</var>) and an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin" id="ref-for-concept-origin③">origin</a> (<var>origin</var>)
-    this algorithm will return a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑥">declared feature policy</a>.</p>
+    this algorithm will return a <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑤">declared feature policy</a>.</p>
      <ol>
       <li>Let <var>policy</var> be an empty ordered map.
       <li>
@@ -1999,8 +2003,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>Let <var>tokens</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace">splitting <var>serialized-declaration</var> on ASCII whitespace.</a>
         <li>If <var>tokens</var> is an empty list, then continue.
         <li>Let <var>feature-name</var> be the first element of <var>tokens</var>.
-        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑥">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑦">policy-controlled feature</a> identified by <var>feature-name</var>.
+        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑤">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑥">policy-controlled feature</a> identified by <var>feature-name</var>.
         <li>Let <var>targetlist</var> be the remaining elements, if any, of <var>tokens</var>. 
         <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①①">allowlist</a>. 
         <li>If any element of <var>targetlist</var> is the string
@@ -2108,8 +2112,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>Let <var>tokens</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace" id="ref-for-split-on-ascii-whitespace①">splitting <var>serialized-declaration</var> on ASCII whitespace.</a>
         <li>If <var>tokens</var> is an empty list, then continue.
         <li>Let <var>feature-name</var> be the first element of <var>tokens</var>.
-        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑧">policy-controlled feature</a>, then continue.
-        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑨">policy-controlled feature</a> identified by <var>feature-name</var>.
+        <li>If <var>feature-name</var> does not identify any recognized <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑦">policy-controlled feature</a>, then continue.
+        <li>Let <var>feature</var> be the <a data-link-type="dfn" href="#policy-controlled-feature" id="ref-for-policy-controlled-feature①⑧">policy-controlled feature</a> identified by <var>feature-name</var>.
         <li>Let <var>targetlist</var> be the remaining elements, if any, of <var>tokens</var>. 
         <li>Let <var>allowlist</var> be a new <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①②">allowlist</a>. 
         <li>If any element of <var>targetlist</var> is the string
@@ -2146,7 +2150,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="8.7" id="initialize-for-document"><span class="secno">8.7. </span><span class="content">Initialize <var>document</var>’s Feature
     Policy</span><a class="self-link" href="#initialize-for-document"></a></h3>
      <p>Given a Document object (<var>document</var>), this algorithm
-    initialises <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①①">Feature Policy</a></p>
+    initialises <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①②">Feature Policy</a></p>
      <ol>
       <li>Let <var>inherited policies</var> be a new ordered map.
       <li>Let <var>declared policies</var> be a new ordered map.
@@ -2157,7 +2161,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     feature</a> on <var>feature</var> and <var>document</var>’s browsing context. 
         <li>Set <var>inherited policies</var>[<var>feature</var>] to <var>isInherited</var>.
        </ol>
-      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①②">feature policy</a>, with inherited
+      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①③">feature policy</a>, with inherited
       policy set <var>inherited policies</var> and declared policy set <var>declared policies</var>. 
       <li> <a data-link-type="dfn" href="#enforce" id="ref-for-enforce①">Enforce</a> the policy <var>policy</var> on <var>document</var>. 
      </ol>
@@ -2166,7 +2170,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <h3 class="heading settled" data-level="8.8" id="initialize-from-response"><span class="secno">8.8. </span><span class="content">Initialize <var>document</var>’s Feature
     Policy from <var>response</var></span><a class="self-link" href="#initialize-from-response"></a></h3>
      <p>Given a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response②">response</a> (<var>response</var>) and a Document
-    (<var>document</var>), this algorithm populates <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①③">Feature Policy</a></p>
+    (<var>document</var>), this algorithm populates <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①④">Feature Policy</a></p>
      <ol>
       <li>Initialize <var>document</var>’s Feature Policy
       <li>Let <var>inherited policies</var> be <var>document</var>’s Feature
@@ -2179,7 +2183,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>If <var>inherited policies</var>[<var>feature</var>] is true, then
 	  set <var>declared policies</var>[<var>feature</var>] to <var>allowlist</var>.
        </ol>
-      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①④">feature policy</a>, with inherited
+      <li>Let <var>policy</var> be a new <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑤">feature policy</a>, with inherited
       policy set <var>inherited policies</var> and declared policy set <var>declared policies</var>. 
       <li> <a data-link-type="dfn" href="#enforce" id="ref-for-enforce②">Enforce</a> the policy <var>policy</var> on <var>document</var>. 
      </ol>
@@ -2187,7 +2191,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <section>
      <h3 class="heading settled" data-level="8.9" id="define-inherited-policy"><span class="secno">8.9. </span><span class="content">Define an inherited policy for <var>feature</var></span><a class="self-link" href="#define-inherited-policy"></a></h3>
      <p>Given a string (<var>feature</var>) and a browsing context
-    (<var>context</var>), this algorithm returns the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy②">inherited policy</a> for that feature.</p>
+    (<var>context</var>), this algorithm returns the <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy③">inherited policy</a> for that feature.</p>
      <ol>
       <li>
        If <var>context</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context" id="ref-for-nested-browsing-context②">nested browsing context</a>: 
@@ -2200,7 +2204,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li>
          If <var>feature</var> is a key in <var>container policy</var>: 
          <ol>
-          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①③">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy③">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
+          <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①③">allowlist</a> for <var>feature</var> in <var>container policy</var> <a data-link-type="dfn" href="#matches" id="ref-for-matches">matches</a> <var>origin</var>, and <var>parent</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy④">inherited policy</a> for <var>feature</var> is Enabled, return Enabled. 
           <li>Otherwise return Disabled.
          </ol>
         <li>Otherwise, if feature is enabled in <var>parent</var> for <var>origin</var>, return Enabled. 
@@ -2216,13 +2220,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     returns "<code>Disabled</code>" if <var>feature</var> should be considered
     disabled, and "<code>Enabled</code>" otherwise.</p>
      <ol>
-      <li>Let <var>policy</var> be <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑤">Feature Policy</a> 
-      <li>If <var>policy</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy④">inherited policy</a> for <var>feature</var> is Disabled, return "<code>Disabled</code>".
+      <li>Let <var>policy</var> be <var>document</var>’s <a data-link-type="dfn" href="#feature-policy" id="ref-for-feature-policy①⑥">Feature Policy</a> 
+      <li>If <var>policy</var>’s <a data-link-type="dfn" href="#inherited-policy" id="ref-for-inherited-policy⑤">inherited policy</a> for <var>feature</var> is Disabled, return "<code>Disabled</code>".
       <li>
-       If <var>feature</var> is present in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑦">declared
+       If <var>feature</var> is present in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑥">declared
       policy</a>: 
        <ol>
-        <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①④">allowlist</a> for <var>feature</var> in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑧">declared policy</a> <a data-link-type="dfn" href="#matches" id="ref-for-matches①">matches</a> <var>origin</var>, then return "<code>Enabled</code>". 
+        <li>If the <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①④">allowlist</a> for <var>feature</var> in <var>policy</var>’s <a data-link-type="dfn" href="#declared-policy" id="ref-for-declared-policy⑦">declared policy</a> <a data-link-type="dfn" href="#matches" id="ref-for-matches①">matches</a> <var>origin</var>, then return "<code>Enabled</code>". 
         <li>Otherwise return "<code>Disabled</code>".
        </ol>
       <li>If <var>feature</var>’s <a data-link-type="dfn" href="#default-allowlist" id="ref-for-default-allowlist③">default allowlist</a> is <code>*</code>, return "<code>Enabled</code>". 
@@ -2417,9 +2421,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#enforce">enforce</a><span>, in §7.1</span>
    <li><a href="#feature-identifier">feature-identifier</a><span>, in §5.1</span>
    <li><a href="#feature-policy">feature policy</a><span>, in §4.2</span>
-   <li><a href="#feature-policy-aware">feature-policy-aware</a><span>, in §4.4</span>
    <li><a href="#feature-policy-header">feature-policy-header</a><span>, in §6.1</span>
-   <li><a href="#feature-policy-oblivious">feature-policy-oblivious</a><span>, in §4.4</span>
    <li><a href="#header-policy">header policy</a><span>, in §4.5</span>
    <li><a href="#inherited-policy">inherited policies</a><span>, in §4.3</span>
    <li><a href="#inherited-policy">inherited policy</a><span>, in §4.3</span>
@@ -2512,7 +2514,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-fullscreen">[FULLSCREEN]
-   <dd>Philip Jägenstedt. <a href="https://fullscreen.spec.whatwg.org/">Fullscreen API Standard</a>. Living Standard. URL: <a href="https://fullscreen.spec.whatwg.org/">https://fullscreen.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://fullscreen.spec.whatwg.org/">Fullscreen API Standard</a>. Living Standard. URL: <a href="https://fullscreen.spec.whatwg.org/">https://fullscreen.spec.whatwg.org/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-infra">[INFRA]
@@ -2549,32 +2551,39 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">4.1. Policy-controlled Features</a> <a href="#ref-for-policy-controlled-feature①">(2)</a> <a href="#ref-for-policy-controlled-feature②">(3)</a> <a href="#ref-for-policy-controlled-feature③">(4)</a> <a href="#ref-for-policy-controlled-feature④">(5)</a> <a href="#ref-for-policy-controlled-feature⑤">(6)</a>
     <li><a href="#ref-for-policy-controlled-feature⑥">4.2. Policies</a>
-    <li><a href="#ref-for-policy-controlled-feature⑦">4.3. Inherited policies</a> <a href="#ref-for-policy-controlled-feature⑧">(2)</a> <a href="#ref-for-policy-controlled-feature⑨">(3)</a>
-    <li><a href="#ref-for-policy-controlled-feature①⓪">4.4. Declared policies</a>
-    <li><a href="#ref-for-policy-controlled-feature①①">4.7. Policy directives</a>
-    <li><a href="#ref-for-policy-controlled-feature①②">4.9. Default Allowlists</a> <a href="#ref-for-policy-controlled-feature①③">(2)</a>
-    <li><a href="#ref-for-policy-controlled-feature①④">6.2. The allow attribute of the
+    <li><a href="#ref-for-policy-controlled-feature⑦">4.3. Inherited policies</a> <a href="#ref-for-policy-controlled-feature⑧">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature⑨">4.4. Declared policies</a>
+    <li><a href="#ref-for-policy-controlled-feature①⓪">4.7. Policy directives</a>
+    <li><a href="#ref-for-policy-controlled-feature①①">4.9. Default Allowlists</a> <a href="#ref-for-policy-controlled-feature①②">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①③">6.2. The allow attribute of the
     iframe element</a>
-    <li><a href="#ref-for-policy-controlled-feature①⑤">6.3. Additional attributes to support legacy
+    <li><a href="#ref-for-policy-controlled-feature①④">6.3. Additional attributes to support legacy
     features</a>
-    <li><a href="#ref-for-policy-controlled-feature①⑥">8.3. Parse policy directive from
-    value and origin</a> <a href="#ref-for-policy-controlled-feature①⑦">(2)</a>
-    <li><a href="#ref-for-policy-controlled-feature①⑧">8.6. Parse allow attribute</a> <a href="#ref-for-policy-controlled-feature①⑨">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①⑤">8.3. Parse policy directive from
+    value and origin</a> <a href="#ref-for-policy-controlled-feature①⑥">(2)</a>
+    <li><a href="#ref-for-policy-controlled-feature①⑦">8.6. Parse allow attribute</a> <a href="#ref-for-policy-controlled-feature①⑧">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="supported-features">
+   <b><a href="#supported-features">#supported-features</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-supported-features">4.3. Inherited policies</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="feature-policy">
    <b><a href="#feature-policy">#feature-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-policy">4.1. Policy-controlled Features</a>
-    <li><a href="#ref-for-feature-policy①">4.5. Header policies</a>
-    <li><a href="#ref-for-feature-policy②">6.1. Feature-Policy HTTP Header
+    <li><a href="#ref-for-feature-policy①">4.3. Inherited policies</a>
+    <li><a href="#ref-for-feature-policy②">4.5. Header policies</a>
+    <li><a href="#ref-for-feature-policy③">6.1. Feature-Policy HTTP Header
     Field</a>
-    <li><a href="#ref-for-feature-policy③">7.1. Integration with HTML</a> <a href="#ref-for-feature-policy④">(2)</a> <a href="#ref-for-feature-policy⑤">(3)</a> <a href="#ref-for-feature-policy⑥">(4)</a> <a href="#ref-for-feature-policy⑦">(5)</a> <a href="#ref-for-feature-policy⑧">(6)</a> <a href="#ref-for-feature-policy⑨">(7)</a> <a href="#ref-for-feature-policy①⓪">(8)</a>
-    <li><a href="#ref-for-feature-policy①①">8.7. Initialize document’s Feature
-    Policy</a> <a href="#ref-for-feature-policy①②">(2)</a>
-    <li><a href="#ref-for-feature-policy①③">8.8. Initialize document’s Feature
-    Policy from response</a> <a href="#ref-for-feature-policy①④">(2)</a>
-    <li><a href="#ref-for-feature-policy①⑤">8.10. Is feature enabled in
+    <li><a href="#ref-for-feature-policy④">7.1. Integration with HTML</a> <a href="#ref-for-feature-policy⑤">(2)</a> <a href="#ref-for-feature-policy⑥">(3)</a> <a href="#ref-for-feature-policy⑦">(4)</a> <a href="#ref-for-feature-policy⑧">(5)</a> <a href="#ref-for-feature-policy⑨">(6)</a> <a href="#ref-for-feature-policy①⓪">(7)</a> <a href="#ref-for-feature-policy①①">(8)</a>
+    <li><a href="#ref-for-feature-policy①②">8.7. Initialize document’s Feature
+    Policy</a> <a href="#ref-for-feature-policy①③">(2)</a>
+    <li><a href="#ref-for-feature-policy①④">8.8. Initialize document’s Feature
+    Policy from response</a> <a href="#ref-for-feature-policy①⑤">(2)</a>
+    <li><a href="#ref-for-feature-policy①⑥">8.10. Is feature enabled in
     document for origin?</a>
    </ul>
   </aside>
@@ -2587,11 +2596,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="inherited-policy">
    <b><a href="#inherited-policy">#inherited-policy</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-inherited-policy">4.3. Inherited policies</a>
-    <li><a href="#ref-for-inherited-policy①">4.6. Container policies</a>
-    <li><a href="#ref-for-inherited-policy②">8.9. Define an inherited policy for
-    feature</a> <a href="#ref-for-inherited-policy③">(2)</a>
-    <li><a href="#ref-for-inherited-policy④">8.10. Is feature enabled in
+    <li><a href="#ref-for-inherited-policy">4.3. Inherited policies</a> <a href="#ref-for-inherited-policy①">(2)</a>
+    <li><a href="#ref-for-inherited-policy②">4.6. Container policies</a>
+    <li><a href="#ref-for-inherited-policy③">8.9. Define an inherited policy for
+    feature</a> <a href="#ref-for-inherited-policy④">(2)</a>
+    <li><a href="#ref-for-inherited-policy⑤">8.10. Is feature enabled in
     document for origin?</a>
    </ul>
   </aside>
@@ -2599,6 +2608,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#inherited-policy-set">#inherited-policy-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-policy-set">4.2. Policies</a> <a href="#ref-for-inherited-policy-set①">(2)</a>
+    <li><a href="#ref-for-inherited-policy-set②">4.3. Inherited policies</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="declared-policy">
@@ -2606,19 +2616,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-declared-policy">4.2. Policies</a> <a href="#ref-for-declared-policy①">(2)</a>
     <li><a href="#ref-for-declared-policy②">4.3. Inherited policies</a>
-    <li><a href="#ref-for-declared-policy③">4.4. Declared policies</a>
-    <li><a href="#ref-for-declared-policy④">4.5. Header policies</a>
-    <li><a href="#ref-for-declared-policy⑤">8.1. Process response policy</a>
-    <li><a href="#ref-for-declared-policy⑥">8.2. Parse header from value and
+    <li><a href="#ref-for-declared-policy③">4.5. Header policies</a>
+    <li><a href="#ref-for-declared-policy④">8.1. Process response policy</a>
+    <li><a href="#ref-for-declared-policy⑤">8.2. Parse header from value and
     origin</a>
-    <li><a href="#ref-for-declared-policy⑦">8.10. Is feature enabled in
-    document for origin?</a> <a href="#ref-for-declared-policy⑧">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="feature-policy-aware">
-   <b><a href="#feature-policy-aware">#feature-policy-aware</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-feature-policy-aware">4.4. Declared policies</a>
+    <li><a href="#ref-for-declared-policy⑥">8.10. Is feature enabled in
+    document for origin?</a> <a href="#ref-for-declared-policy⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="header-policy">

--- a/policies/README.md
+++ b/policies/README.md
@@ -11,3 +11,18 @@ comments on all are wholeheartedly encouraged.
 Nothing in this directory should be construed as having any kind of effect on
 the core Feature Policy specification. Features here, whether implemented or
 not, should be built on top of that framework.
+
+For details on policies in the seamless web talk, please see:
+- [Optimized images](https://github.com/WICG/feature-policy/blob/gh-pages/policies/optimized-images.md), which includes:
+  - Modern formats
+  - No downscaling
+  - Fully compressed
+- [Unsized media](https://github.com/WICG/feature-policy/blob/gh-pages/policies/unsized-media.md)
+- [Fast animations](https://github.com/WICG/feature-policy/blob/gh-pages/policies/animations.md)
+- [Limiting resource sizes](https://github.com/WICG/transfer-size/blob/master/README.md)
+
+The following policies can be enabled via the `experimental-productivity-features` flag in Chrome dev channel:
+- Unsized media
+- Modern formats
+- No downscaling
+- Fast animations


### PR DESCRIPTION
This fixes the issue where both this spec and the suggested changes to
the HTML spec declared that a document "has a" feature policy, but
neither spec explicitly declared what a feature policy "is" in the
absence of a document.

It also tries to clean up some of the other sloppy usage of the term "top-level
document" and "child document" to refer to documents in browsing
contexts instead, and removes the unused spec piece about documents
being "policy-aware" or "policy-oblivious".