### PR TITLE
fix a typo in the allowusermedia session

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -410,7 +410,7 @@ partial interface HTMLIFrameElement {
       <p>The "<code>allowusermedia</code>" iframe attribute controls
       access to <a method>getUserMedia()</a>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
-      value contains the token "<code>payment</code>", then the
+      value contains the token "<code>usermedia</code>", then the
       "<code>allowusermedia</code>" attribute must have no effect.</p>
       <p>Otherwise, the presence of an "<code>allowusermedia</code>" attribute
       on an iframe will result in adding an <a>allowlist</a> of <code>*</code>

--- a/index.html
+++ b/index.html
@@ -1877,7 +1877,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <p>The "<code>allowusermedia</code>" iframe attribute controls
       access to <a class="idl-code" data-link-type="method" href="https://html.spec.whatwg.org/multipage/infrastructure.html#dom-mediadevices-getusermedia" id="ref-for-dom-mediadevices-getusermedia">getUserMedia()</a>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
-      value contains the token "<code>payment</code>", then the
+      value contains the token "<code>usermedia</code>", then the
       "<code>allowusermedia</code>" attribute must have no effect.</p>
       <p>Otherwise, the presence of an "<code>allowusermedia</code>" attribute
       on an iframe will result in adding an <a data-link-type="dfn" href="#allowlist" id="ref-for-allowlist①⓪">allowlist</a> of <code>*</code> for each of the "<code>camera</code>" and "<code>microphone</code>"


### PR DESCRIPTION
> If the iframe element has an "allow" attribute whose value contains the token "payment", then the "allowusermedia" attribute must have no effect.

"payment" seems like a typo here...