### PR TITLE
Update broken WebVR spec links

### DIFF
--- a/features.md
+++ b/features.md
@@ -168,9 +168,9 @@ If disabled in a document, then calls to the [`vibrate()`](https://w3c.github.io
 
 ### vr
 
-The *vr* feature controls whether the current document is allowed to use the [WebVR API](https://w3c.github.io/webvr/spec/1.1/).
+The *vr* feature controls whether the current document is allowed to use the [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/).
 
-If disabled in a document, then calls to the [`getVRDisplays()`](https://w3c.github.io/webvr/spec/1.1/#navigator-getvrdisplays-attribute) should return a promise which rejects with a SecurityError DOMException.
+If disabled in a document, then calls to the [`getVRDisplays()`](https://immersive-web.github.io/webvr/spec/1.1/#navigator-getvrdisplays-attribute) should return a promise which rejects with a SecurityError DOMException.
 
 * The **feature name** for *vr* is "`vr`"
 * The **default allowlist** for *vr* is `'self'`.


### PR DESCRIPTION
The [current link](https://w3c.github.io/webvr/spec/1.1/)(s) are broken, the WebVR spec is now accessible at https://immersive-web.github.io/webvr/spec/1.1/.

However these links may need to change again soon as:
> Development of the WebVR API has halted in favor of being replaced the [WebXR Device API](https://immersive-web.github.io/webxr/). Several browsers will continue to support this version of the API in the meantime.