### PR TITLE
[lazyload.md] Correct parametric policy example

### DIFF
--- a/policies/lazyload.md
+++ b/policies/lazyload.md
@@ -42,6 +42,6 @@ The Extra Mile
 -----------
 In general the feature could allow an expanded set of enforcement policies with the use of [parametric features](https://github.com/WICG/feature-policy/issues/163). For instance, the feature could be used to enforce `lazyload` for certain origins (by enforcing `lazyload='on'` on all resources) and prefer synchronous loading for all local resources (i.e., suggest a default browser behavior of `lazyload='off'`):
 ```
-Feature Policy: 'self'(off) https://example.com(enforce-on)
+Feature Policy: 'self'(off) https://example.com(force)
 ```
 In the example above an image in self such as ``` <img src="./foo.jpg"/>``` (which is same-origin) should be loaded synchronously, but, `<iframe src="https://example.com/page.html" lazyload="off"></iframe>` is loaded lazily due to policy enforcement.

--- a/policies/lazyload.md
+++ b/policies/lazyload.md
@@ -42,6 +42,6 @@ The Extra Mile
 -----------
 In general the feature could allow an expanded set of enforcement policies with the use of [parametric features](https://github.com/WICG/feature-policy/issues/163). For instance, the feature could be used to enforce `lazyload` for certain origins (by enforcing `lazyload='on'` on all resources) and prefer synchronous loading for all local resources (i.e., suggest a default browser behavior of `lazyload='off'`):
 ```
-Feature Policy: 'self'(off) https://example.com(force)
+Feature Policy: lazyload 'self'(off) https://example.com(force)
 ```
 In the example above an image in self such as ``` <img src="./foo.jpg"/>``` (which is same-origin) should be loaded synchronously, but, `<iframe src="https://example.com/page.html" lazyload="off"></iframe>` is loaded lazily due to policy enforcement.


### PR DESCRIPTION
@ehsan-karamad 

The container policy example you gave in https://github.com/WICG/feature-policy/issues/193:
>```
><iframe allow="lazyload *(force)" src="https://www.example.com" lazyload="off"></iframe>
>```
is inconsistent with the [parametric policy example](https://github.com/WICG/feature-policy/blob/master/policies/lazyload.md#the-extra-mile) in the explainer:

> ```
>Feature Policy: 'self'(off) https://example.com(enforce-on)
>```

Should not one of `(force)`  or `(enforce-on)` be used in both instances?
