### PR TITLE
“Should request be allowed to use feature” algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1188,6 +1188,24 @@ partial interface HTMLIFrameElement {
     Note: This algorithm should be called when a feature policy has
     been <a>violated</a>.
   </section>
+  <section>
+    <h3 id="should-request-be-allowed-to-use-feature">Should <var>request</var> be allowed to use <var>feature</var>?</h3>
+    <p>Given a feature (<var>feature</var>) and a  <a for="/">request</a> (<var>request</var>), this algorithm returns <code>true</code> if the request should be allowed to use <var>feature</var>, and <code>false</code> otherwise.</p>
+    <ol>
+      <li>Set |global object| to |request|’s <a for="request">client</a>’s <a for="environment settings object">global object</a>.</li>
+      <li>Set |document| to null.</li>
+      <li>If |global object| is a {{Document}}, set |document| to |global object|.</li>
+      <li>If |global object| is a {{Window}}, set |document| to |global object|’s <a>associated `Document`</a>.</li>
+      <li>If |document| is null, return <code>false</code>.
+        <div class="issue">How can we enable secure use of policy-controlled features within requests initiated by clients that do not have documents? e.g., from within {{WorkerGlobalScope}}s or {{WorkletGlobalScope}}s, i.e., within Service Workers?</div>
+      </li>
+      <li>Let |origin| be |request|’s <a for="request">URL</a>’s <a for="url">origin</a>.</li>
+      <li>Let |result| be the result of executing <a href="is-feature-enabled">Is feature enabled in document for origin?</a> on |feature|, |document|, and |origin|.
+      </li>
+      <li>If |result| is "<code>Enabled</code>", return <code>true</code>.</li>
+      <li>Otherwise, return <code>false</code></li>
+    </ol>
+  </section>
 </section>
 
 <section>


### PR DESCRIPTION
This PR is part of an attempt to address #129 – using Feature Policy to let authors opt-into sending specific Client Hints to specific origins.

The overall, basic idea is:

1. A new set of policy-controlled features – one for each Client Hint header field – is defined in the Client Hints spec.
2. A new algorithm which determines whether a request is able to use a policy-controlled feature is defined in the Feature Policy spec. That's defined in this PR.
3. The step in Fetch that appends Client Hint headers calls the new algorithm, checking if a request is allowed to use a Client Hints’ policy-controlled feature before appending the Client Hint header.