### PR TITLE
Update the 'declared origin' algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -662,11 +662,24 @@ partial interface HTMLIFrameElement {
 
     <p>To get the <dfn>declared origin</dfn> for an Element |node|, run the
     following steps:
-        1. If |node| has a src attribute:
+        1. If |node|'s <a>node document</a>'s <a>sandboxed origin browsing
+            context flag</a> is set, then return a unique opaque origin.
+        1. If |node|'s <{iframe/sandbox}> attribute is specified, and does not
+            contain the <code>allow-same-origin</code> keyword, then return a
+            unique opaque origin.
+        2. If |node|'s <{iframe/srcdoc}> attribute is specified, then return
+            |node|'s <a>node document</a>'s origin.
+        3. If |node|'s <{iframe/src}> attribute is specified:
             1. Let |url| be the result of parsing |node|'s src attribute,
                 relative to |node|'s <a>node document</a>.
             2. If |url| is not failure, return |url|'s origin.
-        2. Return |node|'s <a>node document</a>'s origin.
+        4. Return |node|'s <a>node document</a>'s origin.
+    <p class="note">
+      The <a>declared origin</a> concept is intended to represent the origin of
+      the document which the embedding page intends to load into a frame. This
+      means, for instance, that if the browser does not support the
+      <code>sandbox</code> or <code>srcdoc</code> attributes, it should not take
+      those attributes into account when computing the declared origin.
   </section>
 
 </section>


### PR DESCRIPTION
The steps to get the declared origin for a node did not take into
account the sandbox or srcdoc attributes, which should override the src
attribute if present.

Fixes: 223