### PR TITLE
Fix a typo in features.md

### DIFF
--- a/features.md
+++ b/features.md
@@ -155,7 +155,7 @@ The *sync-xhr* feature controls whether synchronous requests can be made through
 If disabled in a document, then calls to [`send()`](https://xhr.spec.whatwg.org/#the-send()-method) on `XMLHttpRequest` objects with the synchronous flag set will fail, causing a NetworkError DOMException to be thrown.
 
 * The **feature name** for *sync-xhr* is "`sync-xhr`"
-* The **default allowlist** for *speaker* is `*`.
+* The **default allowlist** for *sync-xhr* is `*`.
 
 ### usb
 


### PR DESCRIPTION
This commit will fix a type in `features.md`, where **sync-xhr**'s default **default allowlist** was named as speaker