### PR TITLE
Fix some broken references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,11 +19,13 @@ spec:html; type:dfn; for:/; text:browsing context
 spec:html; type:element; text:script
 spec:html; type:element; text:link
 spec:html; type:method; text:getUserMedia()
-spec:html; type:dfn; text:paymentrequest
 spec:fetch; type:dfn; text:name
 spec:fetch; type:dfn; text:value
 </pre>
 <pre class="anchors">
+spec:payment-request; urlPrefix: https://w3c.github.io/payment-request/
+  type: dfn
+    text: PaymentRequest; url: dom-paymentrequest
 spec:reporting; urlPrefix: https://w3c.github.io/reporting/
   type: dfn
     text: report type
@@ -190,10 +192,10 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
       <li>A <a data-lt="declared policy">declared policy</a>.
       </li>
     </ul>
-    <p>An <dfn>empty feature policy</dfn> is a <a>feature policy</a> that has
-    an <a>inherited policy</a> which contains "<code>Enabled</code>" for every
-    <a>supported feature</a>, and a <a>declared policy</a> which is an empty
-    map.</p>
+    <p>An <dfn export>empty feature policy</dfn> is a <a>feature policy</a> that
+    has an <a>inherited policy</a> which contains "<code>Enabled</code>" for
+    every <a>supported feature</a>, and a <a>declared policy</a> which is an
+    empty map.</p>
   </section>
   <section>
     <h3 id="inherited-policies">Inherited policies</h3>
@@ -201,10 +203,10 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
     policy</dfn> is an ordered map from <a
     data-lt="policy-controlled feature">features</a> to either
     "<code>Enabled</code>" or "<code>Disabled</code>".</p>
-    <p>The <dfn>inherited policy for a feature</dfn> <var>feature</var> is the
-    value in the <a>inherited policy</a> whose key is <var>feature</var>. After
-    a <a>feature policy</a> has been initialized, its <a>inherited policy</a>
-    will contain a value for each <a>supported feature</a>.</p>
+    <p>The <dfn export>inherited policy for a feature</dfn> <var>feature</var>
+    is the value in the <a>inherited policy</a> whose key is <var>feature</var>.
+    After a <a>feature policy</a> has been initialized, its <a>inherited
+    policy</a> will contain a value for each <a>supported feature</a>.</p>
     <div class="note">
     <p>Each document in a frame tree inherits a set of policies from its parent
     frame, or in the case of the top-level document, from the defined defaults
@@ -407,7 +409,7 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
     <section>
       <h4 id="iframe-allowpaymentrequest-attribute">allowpaymentrequest</h4>
       <p>The "<code>allowpaymentrequest</code>" iframe attribute controls
-      access to <a>paymentrequest</a>.</p>
+      access to <a>PaymentRequest</a>.</p>
       <p>If the iframe element has an "<code>allow</code>" attribute whose
       value contains the token "<code>payment</code>", then the
       "<code>allowpaymentrequest</code>" attribute must have no effect.</p>


### PR DESCRIPTION
There were two unexported definitions, and the definition of paymentrequest wasn't pointing to the PaymentRequest spec.