### PR TITLE
Update JS api

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -619,8 +619,14 @@ partial interface HTMLIFrameElement {
     3. If |feature| is allowed by |policy| for |origin|, return true.
     4. Otherwise, return false.
 
+    <p>The {{features()}} method must run the following steps:
+    1. Set |result| to an empty ordered set.
+    2. For each <a>supported feature</a> |feature|:
+        1. Append |feature| to |result|.
+    3. return result
+
     <p>The {{allowedFeatures()}} method must run the following steps:
-    1. Set |result| to an empty list
+    1. Set |result| to an empty ordered set.
     2. Let |origin| be this {{FeaturePolicy}} object's <a>default origin</a>.
     3. Let |policy| be the <a>observable policy</a> for this {{FeaturePolicy}}
         object's <a>associated node</a>.

--- a/index.bs
+++ b/index.bs
@@ -488,20 +488,28 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
   &lt;script&gt;
    const policy = document.featurePolicy;
 
-   // This will be true if this document can use WebUSB
+   // This will be true if this document can use WebUSB.
    const can_use_usb = policy.allowsFeature('usb');
 
-   // True if a new frame at https://example.com will be allowed to use WebVR
+   // True if a new frame at https://example.com will be allowed to use WebVR.
    if (policy.allowsFeature('vr', 'https://example.com')) {
-     // Show UI to create frame at https://example.com
+     // Show UI to create frame at https://example.com.
    } else {
-     // Show an alternative UI
+     // Show an alternative UI.
    }
 
    // Get the list of origins which are allowed to request payment. The result
    // will be a list of explicit origins, or the single element ['\*'] if all
    // origins are allowed.
    const allowed_payment_origins = policy.getAllowlistForFeature('payment');
+
+   // Get the list of all features supported in this document (even those
+   // which are not allowed). The result will be an array of strings, each
+   // representing a feature.
+   const all_features = policy.features();
+   if (all_features.includes('geolocation')) {
+     // Append a child frame to a third-party map service.
+   }
   &lt;/script&gt;
   </pre>
   </div>
@@ -565,6 +573,7 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
 [NoInterfaceObject]
 interface FeaturePolicy {
   boolean <a>allowsFeature</a>(DOMString feature, optional DOMString origin);
+  sequence&lt;DOMString&gt; <a>features</a>();
   sequence&lt;DOMString&gt; <a>allowedFeatures</a>();
   sequence&lt;DOMString&gt; <a>getAllowlistForFeature</a>(DOMString feature);
 };

--- a/index.bs
+++ b/index.bs
@@ -468,21 +468,16 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
   whether a feature is enabled or not. (Some features may not have any
   observable failure mode, or may have unwanted side effects to feature
   detection.)</p>
-  <p>Documents and iframes both provide a {{Policy}} object which can be used to
-  inspect the feature policies which apply to them.</p>
-  <div class="note">
-    The name `policy` is intentionally broad: the {{Policy}} object is intended
-    to be extendable to other kinds of policies, such as Content Security
-    Policy, rather than being exclusively dedicated to Feature Policy. Future
-    methods added to the object should be named appropriately, to indicate the
-    kinds of policies they refer to.
-  </div>
+  <p>Documents and iframes both provide a {{FeaturePolicy}} object which can be
+  used to inspect the feature policies which apply to them.</p>
   <h4 id="document-policies">Document policies</h4>
   <p>To retreive the currently effective policy, use
-  <code>document.policy()</code>. This returns a <a>policy</a> object, which can
-  be used to:
+  <code>document.featurePolicy()</code>. This returns a {{FeaturePolicy}}
+  object, which can be used to:
     * query the state (allowed or denied) in the current document for a given
         feature,
+    * get a list of all available features (allowed or not) in the current
+        document,
     * get a list of all allowed features in the current document, or
     * get the allowlist for a given feature in the current document.
   </p>
@@ -491,10 +486,10 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
   <pre>
   &lt;!doctype html&gt;
   &lt;script&gt;
-   let policy = document.policy;
+   const policy = document.featurePolicy;
 
    // This will be true if this document can use WebUSB
-   let can_use_usb = policy.allowsFeature('usb');
+   const can_use_usb = policy.allowsFeature('usb');
 
    // True if a new frame at https://example.com will be allowed to use WebVR
    if (policy.allowsFeature('vr', 'https://example.com')) {
@@ -506,7 +501,7 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
    // Get the list of origins which are allowed to request payment. The result
    // will be a list of explicit origins, or the single element ['\*'] if all
    // origins are allowed.
-   let allowed_payment_origins = policy.getAllowlistForFeature('payment');
+   const allowed_payment_origins = policy.getAllowlistForFeature('payment');
   &lt;/script&gt;
   </pre>
   </div>
@@ -526,8 +521,8 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
   &lt;!doctype html&gt;
   &lt;iframe id="frame" allow="fullscreen; vr"&gt;&lt;/iframe&gt;
   &lt;script&gt;
-   let iframe_element = document.getElementById("frame");
-   let iframe_policy = iframe_element.policy;
+   const iframe_element = document.getElementById("frame");
+   const iframe_policy = iframe_element.featurePolicy;
 
    // True if the framed document will be allowed to use WebVR
    if (iframe_policy.allowsFeature('vr')) {
@@ -548,75 +543,78 @@ spec:reporting; urlPrefix: https://w3c.github.io/reporting/
       in its src attribute is loaded in it --&gt;
   &lt;iframe id="frame" allow="fullscreen https://example.com" src="https://example.net/" &gt;&lt;/iframe&gt;
   &lt;script&gt;
-   let iframe_element = document.getElementById("frame");
-   let iframe_policy = iframe_element.policy;
+   const iframe_element = document.getElementById("frame");
+   const iframe_policy = iframe_element.featurePolicy;
    // This will be false, as the URL listed in the src attribute is not allowed
    // by policy to use fullscreen.
-   let is_fullscreen_allowed_in_frame = iframe_policy.allowsFeature('fullscreen');
+   const is_fullscreen_allowed_in_frame = iframe_policy.allowsFeature('fullscreen');
 
-   let new_frame = document.createElement('iframe');
+   const new_frame = document.createElement('iframe');
    new_frame.allow = 'syncxhr';
    // This will be true, as the iframe is allowed to use syncxhr at whatever URL is
    // mentioned in its src attribute, even though that attribute is not yet set.
-   let is_syncxhr_allowed = new_frame.policy.allowsFeature('syncxhr');
+   const is_syncxhr_allowed = new_frame.featurePolicy.allowsFeature('syncxhr');
   &lt;/script&gt;
   </pre>
   </div>
   </section>
 
   <section>
-    <h3 id="the-policy-object">The policy object</h3>
+    <h3 id="the-policy-object">The featurePolicy object</h3>
     <pre class="unstable idl">
 [NoInterfaceObject]
-interface Policy {
+interface FeaturePolicy {
   boolean <a>allowsFeature</a>(DOMString feature, optional DOMString origin);
   sequence&lt;DOMString&gt; <a>allowedFeatures</a>();
   sequence&lt;DOMString&gt; <a>getAllowlistForFeature</a>(DOMString feature);
 };
 
 partial interface Document {
-    [SameObject] readonly attribute Policy policy;
+    [SameObject] readonly attribute FeaturePolicy featurePolicy;
 };
 
 partial interface HTMLIFrameElement {
-    [SameObject] readonly attribute Policy policy;
+    [SameObject] readonly attribute FeaturePolicy featurePolicy;
 };</pre>
-    <p>A {{Policy}} object has an <dfn>associated node</dfn>, which is a
-    {{Node}}. The <a>associated node</a> is set when the {{Policy}} object is
-    created.</p>
-    <p>A {{Policy}} object has a <dfn>default origin</dfn>, which is an
-    <a>origin</a>, whose value depends on the state of the {{Policy}} object's
-    <a>associated node</a>:
-    * If the {{Policy}} object's <a>associated node</a> is a {{Document}}, then
-        its <a>default origin</a> is the {{Document}}'s <a>origin</a>.
-    * If the {{Policy}} object's <a>associated node</a> is an {{Element}}, then
-        its <a>default origin</a> is the {{Element}}'s <a>declared origin</a>.
+    <p>A {{FeaturePolicy}} object has an <dfn>associated node</dfn>, which is a
+    {{Node}}. The <a>associated node</a> is set when the {{FeaturePolicy}}
+    object is created.</p>
+    <p>A {{FeaturePolicy}} object has a <dfn>default origin</dfn>, which is an
+    <a>origin</a>, whose value depends on the state of the {{FeaturePolicy}}
+    object's <a>associated node</a>:
+    * If the {{FeaturePolicy}} object's <a>associated node</a> is a
+        {{Document}}, then its <a>default origin</a> is the {{Document}}'s
+	<a>origin</a>.
+    * If the {{FeaturePolicy}} object's <a>associated node</a> is an
+        {{Element}}, then its <a>default origin</a> is the {{Element}}'s
+	<a>declared origin</a>.
 
     <p>Each {{Document}} has a <dfn for="Document">policy object</dfn>, which is
-    a {{Policy}} instance whose <a>associated node</a> is that {{Document}}.</p>
-    <p>A {{Document}}'s {{Document/policy}} IDL attribute, on getting, must
-    return the {{Document}}'s [=Document/policy object=].</p>
+    a {{FeaturePolicy}} instance whose <a>associated node</a> is that
+    {{Document}}.</p>
+    <p>A {{Document}}'s {{Document/featurePolicy}} IDL attribute, on getting,
+    must return the {{Document}}'s [=Document/policy object=].</p>
 
     <p>Each <{iframe}> element has a <dfn for="iframe">policy object</dfn>,
-    which is a {{Policy}} instance whose <a>associated node</a> is that
+    which is a {{FeaturePolicy}} instance whose <a>associated node</a> is that
     element.</p>
-    <p>An <{iframe}>'s {{HTMLIFrameElement/policy}} IDL attribute, on getting, must
-    return the <{iframe}>'s [=iframe/policy object=].</p>
+    <p>An <{iframe}>'s {{HTMLIFrameElement/featurePolicy}} IDL attribute, on
+    getting, must return the <{iframe}>'s [=iframe/policy object=].</p>
 
     <p>The {{allowsFeature(feature, origin)}} method must run the following
     steps:
-    1. If |origin| is omitted, set |origin| to this {{Policy}} object's
+    1. If |origin| is omitted, set |origin| to this {{FeaturePolicy}} object's
         <a>default origin</a>.
-    2. Let |policy| be the <a>observable policy</a> for this {{Policy}} object's
-        <a>associated node</a>.
+    2. Let |policy| be the <a>observable policy</a> for this {{FeaturePolicy}}
+        object's <a>associated node</a>.
     3. If |feature| is allowed by |policy| for |origin|, return true.
     4. Otherwise, return false.
 
     <p>The {{allowedFeatures()}} method must run the following steps:
     1. Set |result| to an empty list
-    2. Let |origin| be this {{Policy}} object's <a>default origin</a>.
-    3. Let |policy| be the <a>observable policy</a> for this {{Policy}} object's
-        <a>associated node</a>.
+    2. Let |origin| be this {{FeaturePolicy}} object's <a>default origin</a>.
+    3. Let |policy| be the <a>observable policy</a> for this {{FeaturePolicy}}
+        object's <a>associated node</a>.
     4. For each <a>supported feature</a> |feature|:
         1. If |feature| is allowed by |policy| for |origin|, append |feature| to
             |result|.
@@ -625,9 +623,9 @@ partial interface HTMLIFrameElement {
     <p>The {{getAllowlistForFeature(feature)}} method must run the following
     steps:
     1. Set |result| to an empty list
-    2. Let |origin| be this {{Policy}} object's <a>default origin</a>.
-    3. Let |policy| be the <a>observable policy</a> for this {{Policy}} object's
-        <a>associated node</a>.
+    2. Let |origin| be this {{FeaturePolicy}} object's <a>default origin</a>.
+    3. Let |policy| be the <a>observable policy</a> for this {{FeaturePolicy}}
+        object's <a>associated node</a>.
     4. If |feature| is not allowed in |policy| for |origin|, return |result|
     5. Let |allowlist| be |policy|'s declared policy[|feature|]
     6. If |allowlist| is the special value `*`, append "`*`" to |result|


### PR DESCRIPTION
This PR updates the JS policy-introspection API in two ways:
 * The attribute on Document and HTMLIFrameElement objects is renamed to `featurePolicy`
 * A `.features()` method is added, to obtain a list of features supported by the browser.

Fixes: #216